### PR TITLE
Add deploy snapshot workflow.

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -1,0 +1,29 @@
+# This workflow will build a Java / Kotlin project with Maven
+
+name: Deploy Snapshots
+
+on:
+  workflow_dispatch:  # Enables manual triggering
+
+jobs:
+  build-and-deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      - name: Configure Maven Settings
+        uses: s4u/maven-settings-action@v2.8.0
+        with:
+          servers: ${{secrets.GITREPO_WRITE_PACKAGE}}
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        
+        run: mvn -DskipTests=true deploy


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the deployment of snapshot builds for a Java/Kotlin project using Maven. The workflow can be manually triggered and includes steps to set up the environment, configure Maven, and deploy the build.

Key changes:

* Added a new workflow configuration file `.github/workflows/deploy-snapshots.yml` to build and deploy snapshots.
  * The workflow is named "Deploy Snapshots" and can be manually triggered using `workflow_dispatch`.
  * It runs on the `ubuntu-latest` environment.
  * Steps include checking out the repository, setting up JDK 21, configuring Maven settings, and running the Maven deploy command with tests skipped.