### PR TITLE
Add dependabot to embabel-common

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This pull request introduces a new `.github/dependabot.yml` configuration file to enable and manage automated dependency updates using Dependabot.

Dependency management setup:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R11): Added a configuration file to specify the use of Dependabot for the `maven` package ecosystem, targeting the root directory (`/`) with a weekly update schedule.