### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,12 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
+registries:
+  github-maven:
+    type: "maven-repository"
+    url: "https://maven.pkg.github.com/embabel/embabel-build"
+    username: "x-access-token"
+    password: "${{ secrets.DEPENDABOT_REPO_TOKEN }}"
 updates:
   - package-ecosystem: "maven"
     directory: "/"


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` file to configure a custom Maven registry for Dependabot. This change allows Dependabot to access dependencies hosted in the specified GitHub Maven repository.

Configuration changes:

* Added a `registries` section to define a custom Maven repository named `github-maven`, including its type, URL, and authentication credentials using a repository token. (`.github/dependabot.yml`, [.github/dependabot.ymlR7-R12](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R7-R12))dependabot