### PR TITLE
Add maven-central and spring repos.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,21 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
+registries:
+  maven-central:
+    type: "maven-repository"
+    url: "https://repo.maven.apache.org/maven2"    
+  spring-milestones:
+    type: "maven-repository"
+    url: "https://repo.spring.io/milestone"
+  spring-snapshots:
+    type: "maven-repository"
+    url: "https://repo.spring.io/snapshot"
+  github-maven:
+    type: "maven-repository"
+    url: "https://maven.pkg.github.com/embabel/embabel-build"
+    username: "x-access-token"
+    password: "${{ secrets.DEPENDABOT_REPO_TOKEN }}"
 updates:
   - package-ecosystem: "maven"
     directory: "/"


### PR DESCRIPTION
This pull request updates the Dependabot configuration file to include custom Maven repositories. These changes ensure that Dependabot can fetch dependencies from additional sources, such as Spring milestones, snapshots, and a GitHub-hosted Maven repository.

### Updates to Dependabot configuration:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R7-R21): Added four custom Maven repositories (`maven-central`, `spring-milestones`, `spring-snapshots`, and `github-maven`) to the `registries` section. The `github-maven` repository includes authentication using a repository token stored in secrets.