### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build](https://github.com/embabel/agent-api/actions/workflows/maven.yml/badge.svg)
+![Build](https://github.com/embabel/embabel-common/actions/workflows/maven.yml/badge.svg)
 
 ![Kotlin](https://img.shields.io/badge/kotlin-%237F52FF.svg?style=for-the-badge&logo=kotlin&logoColor=white)
 ![Spring](https://img.shields.io/badge/spring-%236DB33F.svg?style=for-the-badge&logo=spring&logoColor=white)


### PR DESCRIPTION
This pull request updates the build badge in the `README.md` file to reflect the correct repository.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1): Changed the build badge URL from `embabel/agent-api` to `embabel/embabel-common` to point to the correct repository's build status.