### PR TITLE
Move getLogger and NameUtils out of kotlin package.

### DIFF
--- a/embabel-common-ai/src/main/kotlin/com/embabel/common/ai/model/ApplicationPropertiesModelProvider.kt
+++ b/embabel-common-ai/src/main/kotlin/com/embabel/common/ai/model/ApplicationPropertiesModelProvider.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.common.ai.model
 
-import com.embabel.common.util.kotlin.loggerFor
+import com.embabel.common.util.loggerFor
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.validation.annotation.Validated
 

--- a/embabel-common-ai/src/main/kotlin/com/embabel/common/ai/model/config/OpenAiConfiguration.kt
+++ b/embabel-common-ai/src/main/kotlin/com/embabel/common/ai/model/config/OpenAiConfiguration.kt
@@ -18,7 +18,7 @@ package com.embabel.common.ai.model.config
 import com.embabel.common.ai.model.EmbeddingService
 import com.embabel.common.ai.model.Llm
 import com.embabel.common.util.ExcludeFromJacocoGeneratedReport
-import com.embabel.common.util.kotlin.loggerFor
+import com.embabel.common.util.loggerFor
 import jakarta.validation.constraints.NotBlank
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.ai.document.MetadataMode

--- a/embabel-common-ai/src/test/kotlin/com/embabel/common/ai/prompt/PromptContributorTest.kt
+++ b/embabel-common-ai/src/test/kotlin/com/embabel/common/ai/prompt/PromptContributorTest.kt
@@ -41,35 +41,35 @@ import java.time.format.DateTimeFormatter
  *     - Including contribution content
  */
 class PromptContributorTest {
-    
+
     @Test
     fun `PromptContributor should use class name as default role`() {
         // Create a custom implementation with no role override
         val contributor = object : PromptContributor {
             override fun contribution(): String = "Test content"
         }
-        
+
         // Get the prompt contribution
         val contribution = contributor.promptContribution()
-        
+
         // Role should be the simple class name of the anonymous class
         assertEquals(contributor.javaClass.simpleName, contribution.role)
     }
-    
+
     @Test
     fun `PromptContributor should use BEGINNING as default location`() {
         // Create a custom implementation with no location override
         val contributor = object : PromptContributor {
             override fun contribution(): String = "Test content"
         }
-        
+
         // Get the prompt contribution
         val contribution = contributor.promptContribution()
-        
+
         // Location should be BEGINNING
         assertEquals(PromptContributionLocation.BEGINNING, contribution.location)
     }
-    
+
     @Test
     fun `PromptContributor should allow overriding role and location`() {
         // Create a custom implementation with role and location overrides
@@ -78,25 +78,25 @@ class PromptContributorTest {
             override val promptContributionLocation = PromptContributionLocation.END
             override fun contribution(): String = "Test content"
         }
-        
+
         // Get the prompt contribution
         val contribution = contributor.promptContribution()
-        
+
         // Check that overrides are respected
         assertEquals("custom_role", contribution.role)
         assertEquals(PromptContributionLocation.END, contribution.location)
     }
-    
+
     @Test
     fun `fixed factory method should create contributor with correct properties`() {
         // Test with default parameters
         val defaultContributor = PromptContributor.fixed("Default content")
         val defaultContribution = defaultContributor.promptContribution()
-        
+
         assertEquals("Default content", defaultContribution.content)
         assertNull(defaultContribution.role)
         assertEquals(PromptContributionLocation.BEGINNING, defaultContribution.location)
-        
+
         // Test with custom parameters
         val customContributor = PromptContributor.fixed(
             content = "Custom content",
@@ -104,97 +104,97 @@ class PromptContributorTest {
             location = PromptContributionLocation.END
         )
         val customContribution = customContributor.promptContribution()
-        
+
         assertEquals("Custom content", customContribution.content)
         assertEquals("custom_role", customContribution.role)
         assertEquals(PromptContributionLocation.END, customContribution.location)
     }
-    
+
     @Test
     fun `KnowledgeCutoffDate should format date correctly`() {
         // Create with a specific date
         val date = LocalDate.of(2025, 4, 1)
         val cutoffDate = KnowledgeCutoffDate(date)
-        
+
         // Check content
         val content = cutoffDate.contribution()
         assertTrue(content.contains("Knowledge cutoff: 2025-04"), "Content should contain formatted date: $content")
-        
+
         // Check role
         assertEquals(PromptContribution.KNOWLEDGE_CUTOFF_ROLE, cutoffDate.role)
     }
-    
+
     @Test
     fun `KnowledgeCutoffDate should respect custom formatter`() {
         // Create with a custom formatter
         val date = LocalDate.of(2025, 4, 1)
         val formatter = DateTimeFormatter.ofPattern("MMMM yyyy")
         val cutoffDate = KnowledgeCutoffDate(date, formatter)
-        
+
         // Check content uses custom format
         val content = cutoffDate.contribution()
         assertTrue(content.contains("Knowledge cutoff: April 2025"),
             "Content should use custom formatter: $content")
     }
-    
+
     @Test
     fun `CurrentDate should include current date`() {
         // Create current date contributor
         val currentDate = CurrentDate()
-        
+
         // Get content
         val content = currentDate.contribution()
-        
+
         // Should contain "Current date:" followed by today's date
-        assertTrue(content.startsWith("Current date: "), 
+        assertTrue(content.startsWith("Current date: "),
             "Content should start with 'Current date: ': $content")
-        
+
         // Should contain today's date in the format YYYY-MM-DD
         val today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
-        assertTrue(content.contains(today), 
+        assertTrue(content.contains(today),
             "Content should contain today's date ($today): $content")
-        
+
         // Check role
         assertEquals(PromptContribution.CURRENT_DATE_ROLE, currentDate.role)
     }
-    
+
     @Test
     fun `CurrentDate should respect custom formatter`() {
         // Create with custom formatter
         val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
         val currentDate = CurrentDate(formatter)
-        
+
         // Get content
         val content = currentDate.contribution()
-        
+
         // Should contain today's date in the custom format MM/DD/YYYY
         val today = LocalDate.now().format(formatter)
-        assertTrue(content.contains(today), 
+        assertTrue(content.contains(today),
             "Content should contain today's date in custom format ($today): $content")
     }
-    
+
     @Test
     fun `toString implementations should include contribution content`() {
         // Test KnowledgeCutoffDate toString
         val date = LocalDate.of(2025, 4, 1)
         val cutoffDate = KnowledgeCutoffDate(date)
-        assertTrue(cutoffDate.toString().contains("KnowledgeCutoffDate"), 
+        assertTrue(cutoffDate.toString().contains("KnowledgeCutoffDate"),
             "toString should include class name")
-        assertTrue(cutoffDate.toString().contains(cutoffDate.contribution()), 
+        assertTrue(cutoffDate.toString().contains(cutoffDate.contribution()),
             "toString should include contribution content")
-        
+
         // Test CurrentDate toString
         val currentDate = CurrentDate()
-        assertTrue(currentDate.toString().contains("CurrentDate"), 
+        assertTrue(currentDate.toString().contains("CurrentDate"),
             "toString should include class name")
-        assertTrue(currentDate.toString().contains("Current date:"), 
+        assertTrue(currentDate.toString().contains("Current date:"),
             "toString should include contribution content")
-        
+
         // Test FixedPromptContributor toString
         val fixed = PromptContributor.fixed("Test content")
-        assertTrue(fixed.toString().contains("FixedPromptContributor"), 
+        assertTrue(fixed.toString().contains("FixedPromptContributor"),
             "toString should include class name")
-        assertTrue(fixed.toString().contains("Test content"), 
+        assertTrue(fixed.toString().contains("Test content"),
             "toString should include contribution content")
     }
 }

--- a/embabel-common-test/embabel-common-test-ai/src/main/kotlin/com/embabel/common/test/ai/config/FakeAiConfiguration.kt
+++ b/embabel-common-test/embabel-common-test-ai/src/main/kotlin/com/embabel/common/test/ai/config/FakeAiConfiguration.kt
@@ -18,7 +18,7 @@ package com.embabel.common.test.ai.config
 import com.embabel.common.ai.model.EmbeddingService
 import com.embabel.common.ai.model.Llm
 import com.embabel.common.test.ai.FakeEmbeddingModel
-import com.embabel.common.util.kotlin.loggerFor
+import com.embabel.common.util.loggerFor
 import io.mockk.mockk
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.boot.test.context.TestConfiguration

--- a/embabel-common-util/src/main/kotlin/com/embabel/common/util/GetLogger.kt
+++ b/embabel-common-util/src/main/kotlin/com/embabel/common/util/GetLogger.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.common.util.kotlin
+package com.embabel.common.util
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory

--- a/embabel-common-util/src/main/kotlin/com/embabel/common/util/NamingUtils.kt
+++ b/embabel-common-util/src/main/kotlin/com/embabel/common/util/NamingUtils.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.common.util.kotlin
+package com.embabel.common.util
 
 
 /**


### PR DESCRIPTION
This pull request refactors the package structure for utility classes by moving them out of the `kotlin` subpackage and updating all references accordingly. The most important changes include renaming files, updating package declarations, and modifying import statements in dependent files.

### Package restructuring:

* [`embabel-common-util/src/main/kotlin/com/embabel/common/util/GetLogger.kt`](diffhunk://#diff-c41c5f3f8742b7c82eef5b667f2bf28eb3ba1b1fa7ecc4f69f869fb8a9d14e0dL16-R16): Renamed from `embabel-common-util/src/main/kotlin/com/embabel/common/util/kotlin/GetLogger.kt` and updated the package declaration to `com.embabel.common.util`.
* [`embabel-common-util/src/main/kotlin/com/embabel/common/util/NamingUtils.kt`](diffhunk://#diff-f46b3ddc317d65af75f530ed7fb4b6672bb3c46fec8e67a279af55adae0f1e37L16-R16): Renamed from `embabel-common-util/src/main/kotlin/com/embabel/common/util/kotlin/NamingUtils.kt` and updated the package declaration to `com.embabel.common.util`.

### Import updates:

* [`embabel-common-ai/src/main/kotlin/com/embabel/common/ai/model/ApplicationPropertiesModelProvider.kt`](diffhunk://#diff-88b51d8a06fc010dd91683906881e4a2dfc7594f7ee641c89b81c27eb43ce8eaL18-R18): Updated the import statement for `loggerFor` to reflect the new package structure.
* [`embabel-common-ai/src/main/kotlin/com/embabel/common/ai/model/config/OpenAiConfiguration.kt`](diffhunk://#diff-1a3ef76f4add950e597f435ed8f4509d06478e11cad430b7443d5c22a8a792e4L21-R21): Updated the import statement for `loggerFor` to reflect the new package structure.
* [`embabel-common-test/embabel-common-test-ai/src/main/kotlin/com/embabel/common/test/ai/config/FakeAiConfiguration.kt`](diffhunk://#diff-a9ee22fbc888689ba4da6404f9d3a88dbff1cfccee1ee9d617afe9a8a310f933L21-R21): Updated the import statement for `loggerFor` to reflect the new package structure.