### PR TITLE
Artifactory

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Configure Maven Settings
         uses: s4u/maven-settings-action@v2.8.0
         with:
-          servers: ${{secrets.GITREPO_WRITE_PACKAGE}}
+          servers: ${{secrets.EMBABEL_ARTIFACTORY}}
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,10 +20,6 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: maven
-      - name: Configure Maven Settings
-        uses: s4u/maven-settings-action@v2.8.0
-        with:
-          servers: ${{secrets.GITREPO_SERVER}}
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/embabel-common-dependencies/pom.xml
+++ b/embabel-common-dependencies/pom.xml
@@ -47,19 +47,12 @@
 
     <repositories>
         <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/embabel/embabel-build</url>
+            <id>embabel-snapshots</id>
+            <url>https://repo.embabel.com/artifactory/libs-snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
         </repository>
     </repositories>
-
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/embabel/embabel-common</url>
-        </repository>
-    </distributionManagement>
     
 </project>

--- a/embabel-common-test/embabel-common-test-dependencies/pom.xml
+++ b/embabel-common-test/embabel-common-test-dependencies/pom.xml
@@ -34,19 +34,12 @@
 
     <repositories>
         <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/embabel/embabel-build</url>
+            <id>embabel-snapshots</id>
+            <url>https://repo.embabel.com/artifactory/libs-snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
         </repository>
     </repositories>
-
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/embabel/embabel-common</url>
-        </repository>
-    </distributionManagement>
     
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,10 @@
     <name>Embabel Common Parent</name>
     <description>Common dependencies shared by child modules.</description>
 
+    <properties>
+        <mockk.version>1.13.3</mockk.version>
+    </properties>
+
     <modules>
         <module>embabel-common-dependencies</module>
         <module>embabel-common-core</module>
@@ -66,7 +70,6 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test</artifactId>
-            <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -79,7 +82,7 @@
         <dependency>
             <groupId>io.mockk</groupId>
             <artifactId>mockk-jvm</artifactId>
-            <version>1.13.3</version>
+            <version>${mockk.version}</version>
         </dependency>
 
     </dependencies>
@@ -95,19 +98,12 @@
 
     <repositories>
         <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/embabel/embabel-build</url>
+            <id>embabel-snapshots</id>
+            <url>https://repo.embabel.com/artifactory/libs-snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
         </repository>
     </repositories>
-
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/embabel/embabel-common</url>
-        </repository>
-    </distributionManagement>
 
 </project>


### PR DESCRIPTION
This pull request updates Maven configuration across multiple files to switch from GitHub Packages to Artifactory for dependency and snapshot management. It also introduces a new property for managing the `mockk` dependency version. Below are the most important changes:

### Migration to Artifactory:

* [`.github/workflows/deploy-snapshots.yml`](diffhunk://#diff-441fb097201dd492df86898768fa710e824a03b73403c88c6e4b84404bc76528L24-R24): Updated Maven settings to use the `EMBABEL_ARTIFACTORY` secret instead of `GITREPO_WRITE_PACKAGE`.
* [`.github/workflows/maven.yml`](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446L23-L26): Removed the step for configuring Maven settings with `GITREPO_SERVER`, as it is no longer needed.
* `pom.xml`, `embabel-common-dependencies/pom.xml`, `embabel-common-test/embabel-common-test-dependencies/pom.xml`: Replaced the `github` repository with `embabel-snapshots` pointing to Artifactory and removed the `distributionManagement` section related to GitHub Packages. [[1]](diffhunk://#diff-0e3fdedb8455c8328f840d80ffe03435e184e37f2f5ed4d12c34e66efba89b7eL50-L64) [[2]](diffhunk://#diff-6933ead185e02aa51e35f863660aa72fba9b2cbd3dec13ce43d82c156ebd5f9cL37-L51) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L98-L112)

### Dependency Management:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R17-R20): Added a new `mockk.version` property to centralize the version management of the `mockk` dependency. Updated the `mockk-jvm` dependency to use this property. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R17-R20) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L82-R85)