### PR TITLE
Fix missing test scope for mockk-jvm

### DIFF
--- a/embabel-common-test/pom.xml
+++ b/embabel-common-test/pom.xml
@@ -12,6 +12,10 @@
     <name>Embabel Common Test Parent</name>
     <description>Embabel Test Classes and Framework shared across Embabel Modules.</description>
 
+    <properties>
+        <mockk.version>1.13.3</mockk.version>
+    </properties>
+
     <modules>
         <module>embabel-common-test-dependencies</module>
         <module>embabel-common-test-ai</module>
@@ -33,6 +37,13 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk-jvm</artifactId>
+            <version>${mockk.version}</version>
+        </dependency>
+
     </dependencies>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
             <groupId>io.mockk</groupId>
             <artifactId>mockk-jvm</artifactId>
             <version>${mockk.version}</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
This pull request includes a minor update to the `pom.xml` file to specify the scope of the `mockk-jvm` dependency as `test`. This change ensures the dependency is only included in the test classpath and not in the production build.