### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Binary Packages are located in github repository
 
 ```xml
 <repository>
-    <id>github</id>
-    <url>https://maven.pkg.github.com/embabel/embabel-common</url>
+    <id>embabel-snapshots</id>
+    <url>https://repo.embabel.com/artifactory/libs-snapshot</url>
     <snapshots>
          <enabled>true</enabled>
     </snapshots>


### PR DESCRIPTION
This pull request updates the repository configuration in the `README.md` file to reflect a new location for binary packages.

* Updated the Maven repository configuration: Changed the repository ID from `github` to `embabel-snapshots` and updated the URL to point to `https://repo.embabel.com/artifactory/libs-snapshot` instead of the GitHub repository. (`README.md`, [README.mdL83-R84](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L83-R84))