### PR TITLE
Add managed plugins to generate sources.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,14 @@
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This pull request updates the `pom.xml` file to include additional Maven plugins for enhanced build capabilities. The added plugins are the `build-helper-maven-plugin` and the `maven-source-plugin`.

Build enhancements:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R97-R104): Added the `build-helper-maven-plugin` to assist with build-related tasks.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R97-R104): Added the `maven-source-plugin` to generate source JARs for better distribution and debugging.