### PR TITLE
Update version to 0.1.0-SNAPSHOT

### DIFF
--- a/embabel-common-ai/pom.xml
+++ b/embabel-common-ai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.common</groupId>
         <artifactId>embabel-common-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>embabel-common-ai</artifactId>
     <packaging>jar</packaging>

--- a/embabel-common-core/pom.xml
+++ b/embabel-common-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.common</groupId>
         <artifactId>embabel-common-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>embabel-common-core</artifactId>
     <packaging>jar</packaging>

--- a/embabel-common-dependencies/pom.xml
+++ b/embabel-common-dependencies/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>com.embabel.common</groupId>
     <artifactId>embabel-common-dependencies</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Embabel Common Dependencies</name>
     <description>Embabel Common Dependencies for internal or external modules</description>

--- a/embabel-common-test/embabel-common-test-ai/pom.xml
+++ b/embabel-common-test/embabel-common-test-ai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.common</groupId>
         <artifactId>embabel-common-test</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>embabel-common-test-ai</artifactId>
     <packaging>jar</packaging>

--- a/embabel-common-test/embabel-common-test-dependencies/pom.xml
+++ b/embabel-common-test/embabel-common-test-dependencies/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <groupId>com.embabel.common</groupId>
     <artifactId>embabel-common-test-dependencies</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Embabel Common Test Dependencies</name>
     <description>Embabel Common Test Framework Dependencies</description>

--- a/embabel-common-test/embabel-common-test-neo/pom.xml
+++ b/embabel-common-test/embabel-common-test-neo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.common</groupId>
         <artifactId>embabel-common-test</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>embabel-common-test-neo</artifactId>
     <packaging>jar</packaging>

--- a/embabel-common-test/pom.xml
+++ b/embabel-common-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.common</groupId>
         <artifactId>embabel-common-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>embabel-common-test</artifactId>
     <packaging>pom</packaging>

--- a/embabel-common-textio/pom.xml
+++ b/embabel-common-textio/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.common</groupId>
         <artifactId>embabel-common-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>embabel-common-textio</artifactId>
     <packaging>jar</packaging>

--- a/embabel-common-util/pom.xml
+++ b/embabel-common-util/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.common</groupId>
         <artifactId>embabel-common-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>embabel-common-util</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.common</groupId>
     <artifactId>embabel-common-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Embabel Common Parent</name>
     <description>Common dependencies shared by child modules.</description>


### PR DESCRIPTION
This pull request updates the versioning across multiple Maven `pom.xml` files in the project, changing the version from `1.0.0-SNAPSHOT` to `0.1.0-SNAPSHOT`. This change ensures consistency in versioning across all modules and reflects a downgrade in the snapshot version for better alignment with the project's current stage.

Version updates across modules:

* [`embabel-common-ai/pom.xml`](diffhunk://#diff-33942864c6f2ef0acf32a0e926658137c92210bcd7f404f1d78835ab4034e001L8-R8): Updated parent version to `0.1.0-SNAPSHOT`.
* [`embabel-common-core/pom.xml`](diffhunk://#diff-7be380f5e0c9f11ad3c61d6643129230d8736a6c83388e0bd3903ab38c424dcdL8-R8): Updated parent version to `0.1.0-SNAPSHOT`.
* [`embabel-common-dependencies/pom.xml`](diffhunk://#diff-0e3fdedb8455c8328f840d80ffe03435e184e37f2f5ed4d12c34e66efba89b7eL9-R14): Updated both parent and module versions to `0.1.0-SNAPSHOT`.
* [`embabel-common-test/embabel-common-test-ai/pom.xml`](diffhunk://#diff-ce852ebd0bbae276ac17f7fc80888cc77e916df177013e3762fbb1562cd26057L8-R8): Updated parent version to `0.1.0-SNAPSHOT`.
* [`embabel-common-test/pom.xml`](diffhunk://#diff-44ff3f5f25373a258c54f648f8ff4def6d7c53a911480f387851b4aea5d191a0L8-R8): Updated parent version to `0.1.0-SNAPSHOT`.

Additional updates:

* [`embabel-common-test/embabel-common-test-dependencies/pom.xml`](diffhunk://#diff-6933ead185e02aa51e35f863660aa72fba9b2cbd3dec13ce43d82c156ebd5f9cL9-R14): Updated both parent and module versions to `0.1.0-SNAPSHOT`.
* [`embabel-common-test/embabel-common-test-neo/pom.xml`](diffhunk://#diff-545332445dcfac6487586584baef69322545eba3c3fec066b7fb7d3f2150880dL8-R8): Updated parent version to `0.1.0-SNAPSHOT`.
* [`embabel-common-textio/pom.xml`](diffhunk://#diff-393901ff195cd163c3fd0c62fa618ebc597759170c3fd02c1c49271ac0797f0fL8-R8): Updated parent version to `0.1.0-SNAPSHOT`.
* [`embabel-common-util/pom.xml`](diffhunk://#diff-a5e090c117815709b5c209a12ea357715490461221e75b85a3e72768a692b1bbL8-R8): Updated parent version to `0.1.0-SNAPSHOT`.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L8-R12): Updated both parent and module versions to `0.1.0-SNAPSHOT`.