### PR TITLE
Add support to change Font to Cascadia Code on Windows

### DIFF
--- a/embabel-common-util/src/main/kotlin/com/embabel/common/util/WinUtils.kt
+++ b/embabel-common-util/src/main/kotlin/com/embabel/common/util/WinUtils.kt
@@ -15,8 +15,55 @@
  */
 package com.embabel.common.util
 
+import com.sun.jna.Native
+import com.sun.jna.Structure
 import com.sun.jna.platform.win32.Kernel32
+import com.sun.jna.platform.win32.WinNT
 import org.apache.commons.lang3.SystemUtils
+
+/**
+ * Console font information structure for Windows API.
+ * Must be public for JNA reflection access.
+ */
+class ConsoleFontInfoEx : Structure() {
+    @JvmField var cbSize: Int = 0
+    @JvmField var nFont: Int = 0
+    @JvmField var dwFontSize: Coord = Coord()
+    @JvmField var FontFamily: Int = 0
+    @JvmField var FontWeight: Int = 0
+    @JvmField var FaceName: CharArray = CharArray(32)
+
+    class Coord : Structure() {
+        @JvmField var X: Short = 0
+        @JvmField var Y: Short = 0
+        override fun getFieldOrder(): List<String> = listOf("X", "Y")
+    }
+
+    override fun getFieldOrder(): List<String> =
+        listOf("cbSize", "nFont", "dwFontSize", "FontFamily", "FontWeight", "FaceName")
+}
+
+/**
+ * Extended Kernel32 interface for console font operations.
+ * Must be public for JNA access.
+ */
+interface Kernel32Extended : Kernel32 {
+    companion object {
+        val INSTANCE: Kernel32Extended = Native.load("kernel32", Kernel32Extended::class.java)
+    }
+
+    fun SetCurrentConsoleFontEx(
+        hConsoleOutput: WinNT.HANDLE,
+        bMaximumWindow: Boolean,
+        lpConsoleCurrentFontEx: ConsoleFontInfoEx
+    ): Boolean
+
+    fun GetCurrentConsoleFontEx(
+        hConsoleOutput: WinNT.HANDLE,
+        bMaximumWindow: Boolean,
+        lpConsoleCurrentFontEx: ConsoleFontInfoEx
+    ): Boolean
+}
 
 /**
  * Utility class for Windows-specific operations.
@@ -25,7 +72,6 @@ import org.apache.commons.lang3.SystemUtils
 class WinUtils {
 
     companion object {
-
         const val UTF8_CODEPAGE = 65001
 
         /**
@@ -64,6 +110,132 @@ class WinUtils {
             }
             //if not windows then it is supported regardless of what the code page is
             return true
+        }
+
+        /**
+         * Sets the console font to Cascadia Code with UTF-8 support.
+         * Automatically switches to UTF-8 code page for optimal Unicode display.
+         *
+         * @param fontSize Optional font size (default: 16)
+         * @return true if font was successfully changed, false otherwise
+         */
+        @kotlin.jvm.JvmStatic
+        fun SET_CASCADIA_CODE_FONT(fontSize: Short = 16): Boolean { //NOSONAR
+            if (!IS_OS_WINDOWS()) {
+                println("Font switching only supported on Windows")
+                return false
+            }
+
+            return try {
+                // First ensure UTF-8 support
+                CHCP_TO_UTF8()
+
+                // Get console handle
+                val consoleHandle = Kernel32.INSTANCE.GetStdHandle(Kernel32.STD_OUTPUT_HANDLE)
+                if (consoleHandle == null || consoleHandle.equals(WinNT.INVALID_HANDLE_VALUE)) {
+                    println("Failed to get console handle")
+                    return false
+                }
+
+                // Get current font info
+                val fontInfo = ConsoleFontInfoEx()
+                fontInfo.cbSize = fontInfo.size()
+
+                if (!Kernel32Extended.INSTANCE.GetCurrentConsoleFontEx(consoleHandle, false, fontInfo)) {
+                    println("Failed to get current font info")
+                    return false
+                }
+
+                // Set Cascadia Code font
+                fontInfo.apply {
+                    cbSize = size()
+                    FaceName.fill('\u0000')
+                    "Cascadia Code".toCharArray().copyInto(
+                        FaceName,
+                        endIndex = minOf("Cascadia Code".length, FaceName.size - 1)
+                    )
+                    dwFontSize.X = 0 // Width (0 = default)
+                    dwFontSize.Y = fontSize
+                    FontWeight = 400 // Normal weight
+                }
+
+                val success = Kernel32Extended.INSTANCE.SetCurrentConsoleFontEx(consoleHandle, false, fontInfo)
+                if (success) {
+                    println("✓ Console font changed to Cascadia Code (size: $fontSize)")
+                } else {
+                    println("✗ Failed to change console font to Cascadia Code")
+                }
+                success
+
+            } catch (e: Exception) {
+                println("Error changing font: ${e.message}")
+                false
+            }
+        }
+
+        /**
+         * Sets up optimal console for Unicode display.
+         * Tries Cascadia Code first, then falls back to other suitable fonts.
+         *
+         * @return true if any suitable font was successfully applied
+         */
+        @kotlin.jvm.JvmStatic
+        fun SETUP_OPTIMAL_CONSOLE(): Boolean { //NOSONAR
+            if (!IS_OS_WINDOWS()) {
+                println("Console optimization only supported on Windows")
+                return false
+            }
+
+            // Try fonts in order of preference
+            val fonts = arrayOf("Cascadia Code", "Cascadia Mono", "Consolas")
+
+            for (font in fonts) {
+                if (setConsoleFont(font)) {
+                    println("✓ Console optimized with $font font")
+                    return true
+                }
+            }
+
+            println("✗ No suitable Unicode fonts found")
+            return false
+        }
+
+        /**
+         * Private helper to set any console font.
+         */
+        private fun setConsoleFont(fontName: String, fontSize: Short = 16): Boolean {
+            return try {
+                CHCP_TO_UTF8()
+
+                val consoleHandle = Kernel32.INSTANCE.GetStdHandle(Kernel32.STD_OUTPUT_HANDLE)
+                if (consoleHandle == null || consoleHandle.equals(WinNT.INVALID_HANDLE_VALUE)) {
+                    return false
+                }
+
+                val fontInfo = ConsoleFontInfoEx()
+                fontInfo.cbSize = fontInfo.size()
+
+                if (!Kernel32Extended.INSTANCE.GetCurrentConsoleFontEx(consoleHandle, false, fontInfo)) {
+                    return false
+                }
+
+                fontInfo.apply {
+                    cbSize = size()
+                    FaceName.fill('\u0000')
+                    fontName.toCharArray().copyInto(
+                        FaceName,
+                        endIndex = minOf(fontName.length, FaceName.size - 1)
+                    )
+                    dwFontSize.X = 0
+                    dwFontSize.Y = fontSize
+                    FontWeight = 400
+                }
+
+                Kernel32Extended.INSTANCE.SetCurrentConsoleFontEx(consoleHandle, false, fontInfo)
+
+            } catch (e: Exception) {
+                false
+            }
         }
     }
 }

--- a/embabel-common-util/src/test/kotlin/com/embabel/common/util/WinUtilsTest.kt
+++ b/embabel-common-util/src/test/kotlin/com/embabel/common/util/WinUtilsTest.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.common.util
+
+import com.embabel.common.util.WinUtils
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+class WinUtilsTest {
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    fun `is OS Windows`() {
+        assertTrue(WinUtils.IS_OS_WINDOWS())
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    fun `is not OS Windows`() {
+        assertFalse(WinUtils.IS_OS_WINDOWS())
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    fun `chcp(UTF8)`() {
+        WinUtils.CHCP_TO_UTF8()
+        assertTrue(WinUtils.ACTIVE_CONSOLE_CODEPAGE() == WinUtils.UTF8_CODEPAGE)
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    fun `chcp(UTF8) should not be called on Linux`() {
+        assertThrows<Error> { WinUtils.ACTIVE_CONSOLE_CODEPAGE() }
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    fun `active console code page should not be called on Linux`() {
+        assertThrows<Error> { WinUtils.ACTIVE_CONSOLE_CODEPAGE() }
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    fun `AsciiTable is supported on Windows`() {
+        WinUtils.CHCP_TO_UTF8()
+        assertTrue(WinUtils.ASCII_TABLE_SUPPORTED())
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    fun `AsciiTable is supported on Linux`() {
+        assertTrue(WinUtils.ASCII_TABLE_SUPPORTED())
+    }
+
+    // === New Font Tests ===
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    fun `set Cascadia Code font does not throw exception on Windows`() {
+        // Should not throw exception regardless of whether font is available
+        WinUtils.SET_CASCADIA_CODE_FONT()
+        // Test passes if no exception is thrown
+        assertTrue(true)
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    fun `set Cascadia Code font with custom size does not throw exception`() {
+        // Should handle custom font sizes gracefully
+        WinUtils.SET_CASCADIA_CODE_FONT(18)
+        assertTrue(true)
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX, OS.MAC)
+    fun `set Cascadia Code font returns false on non-Windows`() {
+        val result = WinUtils.SET_CASCADIA_CODE_FONT()
+        assertFalse(result)
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    fun `setup optimal console does not throw exception on Windows`() {
+        // Should complete without exceptions
+        WinUtils.SETUP_OPTIMAL_CONSOLE()
+        assertTrue(true)
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX, OS.MAC)
+    fun `setup optimal console returns false on non-Windows`() {
+        val result = WinUtils.SETUP_OPTIMAL_CONSOLE()
+        assertFalse(result)
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    fun `font methods maintain UTF-8 code page`() {
+        // Set UTF-8 first
+        WinUtils.CHCP_TO_UTF8()
+        val initialCodePage = WinUtils.ACTIVE_CONSOLE_CODEPAGE()
+
+        // Try to set font (may succeed or fail)
+        WinUtils.SET_CASCADIA_CODE_FONT()
+
+        // Verify UTF-8 is still active
+        val finalCodePage = WinUtils.ACTIVE_CONSOLE_CODEPAGE()
+        assertTrue(finalCodePage == WinUtils.UTF8_CODEPAGE)
+    }
+
+    @Test
+    fun `font size edge cases do not cause crashes`() {
+        // Test that edge case font sizes don't cause crashes
+
+        // Negative font size
+        try {
+            WinUtils.SET_CASCADIA_CODE_FONT((-1).toShort())
+            // Should complete without exception
+        } catch (e: Exception) {
+            // If exception occurs, it should be handled gracefully
+            assertTrue(e.message?.isNotEmpty() ?: false)
+        }
+
+        // Very large font size
+        try {
+            WinUtils.SET_CASCADIA_CODE_FONT(100)
+            // Should complete without exception
+        } catch (e: Exception) {
+            assertTrue(e.message?.isNotEmpty() ?: false)
+        }
+
+        // Zero font size
+        try {
+            WinUtils.SET_CASCADIA_CODE_FONT(0)
+            // Should complete without exception
+        } catch (e: Exception) {
+            assertTrue(e.message?.isNotEmpty() ?: false)
+        }
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    fun `multiple font operations are safe`() {
+        // Should be safe to call multiple times without exceptions
+        try {
+            WinUtils.SET_CASCADIA_CODE_FONT()
+            WinUtils.SETUP_OPTIMAL_CONSOLE()
+            WinUtils.SET_CASCADIA_CODE_FONT(14)
+            // If we get here, all operations completed
+            assertTrue(true)
+        } catch (e: Exception) {
+            // If exceptions occur, they should be handled gracefully
+            assertTrue(e.message?.isNotEmpty() ?: false)
+        }
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    fun `cascadia code font method preserves console state`() {
+        // Capture initial state
+        val initialCodePage = WinUtils.ACTIVE_CONSOLE_CODEPAGE()
+
+        // Apply font
+        WinUtils.SET_CASCADIA_CODE_FONT()
+
+        // Should have UTF-8 enabled (method calls CHCP_TO_UTF8)
+        val finalCodePage = WinUtils.ACTIVE_CONSOLE_CODEPAGE()
+        assertTrue(finalCodePage == WinUtils.UTF8_CODEPAGE)
+    }
+}

--- a/embabel-common-util/src/test/kotlin/com/embabel/common/util/WinUtilsTest.kt
+++ b/embabel-common-util/src/test/kotlin/com/embabel/common/util/WinUtilsTest.kt
@@ -15,173 +15,390 @@
  */
 package com.embabel.common.util
 
-import com.embabel.common.util.WinUtils
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
 
+@DisplayName("WinUtils")
 class WinUtilsTest {
 
-    @Test
-    @EnabledOnOs(OS.WINDOWS)
-    fun `is OS Windows`() {
-        assertTrue(WinUtils.IS_OS_WINDOWS())
-    }
+    @Nested
+    @DisplayName("Platform Detection")
+    inner class PlatformDetectionTests {
 
-    @Test
-    @EnabledOnOs(OS.LINUX)
-    fun `is not OS Windows`() {
-        assertFalse(WinUtils.IS_OS_WINDOWS())
-    }
-
-    @Test
-    @EnabledOnOs(OS.WINDOWS)
-    fun `chcp(UTF8)`() {
-        WinUtils.CHCP_TO_UTF8()
-        assertTrue(WinUtils.ACTIVE_CONSOLE_CODEPAGE() == WinUtils.UTF8_CODEPAGE)
-    }
-
-    @Test
-    @EnabledOnOs(OS.LINUX)
-    fun `chcp(UTF8) should not be called on Linux`() {
-        assertThrows<Error> { WinUtils.ACTIVE_CONSOLE_CODEPAGE() }
-    }
-
-    @Test
-    @EnabledOnOs(OS.LINUX)
-    fun `active console code page should not be called on Linux`() {
-        assertThrows<Error> { WinUtils.ACTIVE_CONSOLE_CODEPAGE() }
-    }
-
-    @Test
-    @EnabledOnOs(OS.WINDOWS)
-    fun `AsciiTable is supported on Windows`() {
-        WinUtils.CHCP_TO_UTF8()
-        assertTrue(WinUtils.ASCII_TABLE_SUPPORTED())
-    }
-
-    @Test
-    @EnabledOnOs(OS.LINUX)
-    fun `AsciiTable is supported on Linux`() {
-        assertTrue(WinUtils.ASCII_TABLE_SUPPORTED())
-    }
-
-    // === New Font Tests ===
-
-    @Test
-    @EnabledOnOs(OS.WINDOWS)
-    fun `set Cascadia Code font does not throw exception on Windows`() {
-        // Should not throw exception regardless of whether font is available
-        WinUtils.SET_CASCADIA_CODE_FONT()
-        // Test passes if no exception is thrown
-        assertTrue(true)
-    }
-
-    @Test
-    @EnabledOnOs(OS.WINDOWS)
-    fun `set Cascadia Code font with custom size does not throw exception`() {
-        // Should handle custom font sizes gracefully
-        WinUtils.SET_CASCADIA_CODE_FONT(18)
-        assertTrue(true)
-    }
-
-    @Test
-    @EnabledOnOs(OS.LINUX, OS.MAC)
-    fun `set Cascadia Code font returns false on non-Windows`() {
-        val result = WinUtils.SET_CASCADIA_CODE_FONT()
-        assertFalse(result)
-    }
-
-    @Test
-    @EnabledOnOs(OS.WINDOWS)
-    fun `setup optimal console does not throw exception on Windows`() {
-        // Should complete without exceptions
-        WinUtils.SETUP_OPTIMAL_CONSOLE()
-        assertTrue(true)
-    }
-
-    @Test
-    @EnabledOnOs(OS.LINUX, OS.MAC)
-    fun `setup optimal console returns false on non-Windows`() {
-        val result = WinUtils.SETUP_OPTIMAL_CONSOLE()
-        assertFalse(result)
-    }
-
-    @Test
-    @EnabledOnOs(OS.WINDOWS)
-    fun `font methods maintain UTF-8 code page`() {
-        // Set UTF-8 first
-        WinUtils.CHCP_TO_UTF8()
-        val initialCodePage = WinUtils.ACTIVE_CONSOLE_CODEPAGE()
-
-        // Try to set font (may succeed or fail)
-        WinUtils.SET_CASCADIA_CODE_FONT()
-
-        // Verify UTF-8 is still active
-        val finalCodePage = WinUtils.ACTIVE_CONSOLE_CODEPAGE()
-        assertTrue(finalCodePage == WinUtils.UTF8_CODEPAGE)
-    }
-
-    @Test
-    fun `font size edge cases do not cause crashes`() {
-        // Test that edge case font sizes don't cause crashes
-
-        // Negative font size
-        try {
-            WinUtils.SET_CASCADIA_CODE_FONT((-1).toShort())
-            // Should complete without exception
-        } catch (e: Exception) {
-            // If exception occurs, it should be handled gracefully
-            assertTrue(e.message?.isNotEmpty() ?: false)
+        @Test
+        @EnabledOnOs(OS.WINDOWS)
+        @DisplayName("should correctly identify Windows OS")
+        fun `identifies Windows OS correctly`() {
+            assertTrue(WinUtils.IS_OS_WINDOWS()) {
+                "Should return true when running on Windows"
+            }
         }
 
-        // Very large font size
-        try {
-            WinUtils.SET_CASCADIA_CODE_FONT(100)
-            // Should complete without exception
-        } catch (e: Exception) {
-            assertTrue(e.message?.isNotEmpty() ?: false)
-        }
-
-        // Zero font size
-        try {
-            WinUtils.SET_CASCADIA_CODE_FONT(0)
-            // Should complete without exception
-        } catch (e: Exception) {
-            assertTrue(e.message?.isNotEmpty() ?: false)
+        @Test
+        @EnabledOnOs(OS.LINUX, OS.MAC)
+        @DisplayName("should correctly identify non-Windows OS")
+        fun `identifies non-Windows OS correctly`() {
+            assertFalse(WinUtils.IS_OS_WINDOWS()) {
+                "Should return false when running on non-Windows platforms"
+            }
         }
     }
 
-    @Test
-    @EnabledOnOs(OS.WINDOWS)
-    fun `multiple font operations are safe`() {
-        // Should be safe to call multiple times without exceptions
-        try {
+    @Nested
+    @DisplayName("Console Code Page Management")
+    inner class CodePageTests {
+
+        @Test
+        @EnabledOnOs(OS.WINDOWS)
+        @DisplayName("should set UTF-8 code page on Windows")
+        fun `sets UTF8 code page on Windows`() {
+            // Given: A Windows environment
+            // When: Setting UTF-8 code page
+            WinUtils.CHCP_TO_UTF8()
+
+            // Then: Code page should be UTF-8
+            assertEquals(WinUtils.UTF8_CODEPAGE, WinUtils.ACTIVE_CONSOLE_CODEPAGE()) {
+                "Console code page should be set to UTF-8 (${WinUtils.UTF8_CODEPAGE})"
+            }
+        }
+
+        @Test
+        @EnabledOnOs(OS.LINUX, OS.MAC)
+        @DisplayName("should throw error when accessing code page on non-Windows")
+        fun `throws error for code page operations on non-Windows`() {
+            assertThrows<Error> {
+                WinUtils.ACTIVE_CONSOLE_CODEPAGE()
+            }
+        }
+
+        @Test
+        @EnabledOnOs(OS.WINDOWS)
+        @DisplayName("should support ASCII table when UTF-8 is active")
+        fun `supports ASCII table with UTF8 on Windows`() {
+            // Given: UTF-8 code page is set
+            WinUtils.CHCP_TO_UTF8()
+
+            // When: Checking ASCII table support
+            val isSupported = WinUtils.ASCII_TABLE_SUPPORTED()
+
+            // Then: Should be supported
+            assertTrue(isSupported) {
+                "ASCII table should be supported when UTF-8 code page is active"
+            }
+        }
+
+        @Test
+        @EnabledOnOs(OS.LINUX, OS.MAC)
+        @DisplayName("should always support ASCII table on non-Windows")
+        fun `always supports ASCII table on non-Windows`() {
+            assertTrue(WinUtils.ASCII_TABLE_SUPPORTED()) {
+                "ASCII table should always be supported on non-Windows platforms"
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Font Management")
+    inner class FontManagementTests {
+
+        @Test
+        @EnabledOnOs(OS.WINDOWS)
+        @DisplayName("should handle Cascadia Code font setting gracefully")
+        fun `handles Cascadia Code font setting on Windows`() {
+            // Given: A Windows environment
+            // When: Setting Cascadia Code font (may succeed or fail based on font availability)
+            val result = WinUtils.SET_CASCADIA_CODE_FONT()
+
+            // Then: Should not throw exception and UTF-8 should be maintained
+            assertEquals(WinUtils.UTF8_CODEPAGE, WinUtils.ACTIVE_CONSOLE_CODEPAGE()) {
+                "UTF-8 code page should be maintained after font operation"
+            }
+            // Note: We don't assert success/failure as font availability varies by system
+        }
+
+        @Test
+        @EnabledOnOs(OS.WINDOWS)
+        @DisplayName("should preserve font size when no size specified")
+        fun `preserves font size when no size specified`() {
+            // Given: UTF-8 is set up
+            WinUtils.CHCP_TO_UTF8()
+
+            // When: Setting Cascadia Code font without specifying size
             WinUtils.SET_CASCADIA_CODE_FONT()
-            WinUtils.SETUP_OPTIMAL_CONSOLE()
-            WinUtils.SET_CASCADIA_CODE_FONT(14)
-            // If we get here, all operations completed
-            assertTrue(true)
-        } catch (e: Exception) {
-            // If exceptions occur, they should be handled gracefully
-            assertTrue(e.message?.isNotEmpty() ?: false)
+
+            // Then: Should complete without exception (size preservation tested via console output)
+            assertEquals(WinUtils.UTF8_CODEPAGE, WinUtils.ACTIVE_CONSOLE_CODEPAGE()) {
+                "UTF-8 code page should be maintained after font operation with size preservation"
+            }
+        }
+
+        @Test
+        @EnabledOnOs(OS.WINDOWS)
+        @DisplayName("should accept specific font size when provided")
+        fun `accepts specific font size when provided`() {
+            // Given: A Windows environment
+            // When: Setting Cascadia Code font with specific size
+            assertDoesNotThrow {
+                WinUtils.SET_CASCADIA_CODE_FONT(18)
+            }
+
+            // Then: UTF-8 should be maintained
+            assertEquals(WinUtils.UTF8_CODEPAGE, WinUtils.ACTIVE_CONSOLE_CODEPAGE()) {
+                "UTF-8 code page should be maintained after font operation with specific size"
+            }
+        }
+
+        @Test
+        @EnabledOnOs(OS.LINUX, OS.MAC)
+        @DisplayName("should return false for font operations on non-Windows")
+        fun `returns false for font operations on non-Windows`() {
+            val result1 = WinUtils.SET_CASCADIA_CODE_FONT()
+            val result2 = WinUtils.SET_CASCADIA_CODE_FONT(16)
+
+            assertFalse(result1) {
+                "Font operations should return false on non-Windows platforms"
+            }
+            assertFalse(result2) {
+                "Font operations with size should return false on non-Windows platforms"
+            }
+        }
+
+        @ParameterizedTest
+        @ValueSource(shorts = [8, 12, 16, 18, 24, 32])
+        @EnabledOnOs(OS.WINDOWS)
+        @DisplayName("should handle various font sizes gracefully")
+        fun `handles various font sizes gracefully`(fontSize: Short) {
+            // Should complete without throwing exceptions
+            assertDoesNotThrow {
+                WinUtils.SET_CASCADIA_CODE_FONT(fontSize)
+            }
+        }
+
+        @ParameterizedTest
+        @ValueSource(shorts = [-1, 0, 100, 999])
+        @DisplayName("should handle edge case font sizes safely")
+        fun `handles edge case font sizes safely`(fontSize: Short) {
+            // Should not crash with unusual font sizes
+            assertDoesNotThrow {
+                WinUtils.SET_CASCADIA_CODE_FONT(fontSize)
+            }
+        }
+
+        @Test
+        @EnabledOnOs(OS.WINDOWS)
+        @DisplayName("should handle optimal console setup with size preservation")
+        fun `handles optimal console setup with size preservation on Windows`() {
+            // Given: A Windows environment
+            // When: Setting up optimal console
+            val result = WinUtils.SETUP_OPTIMAL_CONSOLE()
+
+            // Then: Should not throw and maintain UTF-8
+            assertEquals(WinUtils.UTF8_CODEPAGE, WinUtils.ACTIVE_CONSOLE_CODEPAGE()) {
+                "UTF-8 code page should be maintained after console optimization"
+            }
+        }
+
+        @Test
+        @EnabledOnOs(OS.LINUX, OS.MAC)
+        @DisplayName("should return false for console optimization on non-Windows")
+        fun `returns false for console optimization on non-Windows`() {
+            val result = WinUtils.SETUP_OPTIMAL_CONSOLE()
+            assertFalse(result) {
+                "Console optimization should return false on non-Windows platforms"
+            }
         }
     }
 
-    @Test
-    @EnabledOnOs(OS.WINDOWS)
-    fun `cascadia code font method preserves console state`() {
-        // Capture initial state
-        val initialCodePage = WinUtils.ACTIVE_CONSOLE_CODEPAGE()
+    @Nested
+    @DisplayName("Error Handling and Resilience")
+    inner class ErrorHandlingTests {
 
-        // Apply font
-        WinUtils.SET_CASCADIA_CODE_FONT()
+        @Test
+        @EnabledOnOs(OS.WINDOWS)
+        @DisplayName("should handle multiple consecutive font operations safely")
+        fun `handles multiple consecutive font operations safely`() {
+            assertDoesNotThrow {
+                WinUtils.SET_CASCADIA_CODE_FONT(12.toShort())
+                WinUtils.SETUP_OPTIMAL_CONSOLE()
+                WinUtils.SET_CASCADIA_CODE_FONT() // size preservation
+                WinUtils.SET_CASCADIA_CODE_FONT(14.toShort())
+            }
+        }
 
-        // Should have UTF-8 enabled (method calls CHCP_TO_UTF8)
-        val finalCodePage = WinUtils.ACTIVE_CONSOLE_CODEPAGE()
-        assertTrue(finalCodePage == WinUtils.UTF8_CODEPAGE)
+        @Test
+        @DisplayName("should maintain consistent state after operations")
+        fun `maintains consistent state after operations`() {
+            if (WinUtils.IS_OS_WINDOWS()) {
+                // Given: Initial UTF-8 setup
+                WinUtils.CHCP_TO_UTF8()
+                val initialCodePage = WinUtils.ACTIVE_CONSOLE_CODEPAGE()
+
+                // When: Performing font operations
+                WinUtils.SET_CASCADIA_CODE_FONT()
+                WinUtils.SETUP_OPTIMAL_CONSOLE()
+
+                // Then: UTF-8 should still be active
+                val finalCodePage = WinUtils.ACTIVE_CONSOLE_CODEPAGE()
+                assertEquals(WinUtils.UTF8_CODEPAGE, finalCodePage) {
+                    "UTF-8 code page should be maintained throughout all operations"
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("should handle null size parameter gracefully")
+        fun `handles null size parameter gracefully`() {
+            // Test that explicit null parameter works the same as no parameter
+            assertDoesNotThrow {
+                WinUtils.SET_CASCADIA_CODE_FONT(null)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Integration and Output Validation")
+    inner class IntegrationTests {
+
+        @Test
+        @EnabledOnOs(OS.WINDOWS)
+        @DisplayName("should provide informative console output with size preservation info")
+        fun `provides informative console output with size preservation info`() {
+            val outputStream = ByteArrayOutputStream()
+            val originalOut = System.out
+
+            try {
+                System.setOut(PrintStream(outputStream))
+
+                WinUtils.CHCP_TO_UTF8()
+                WinUtils.SET_CASCADIA_CODE_FONT()
+
+                val output = outputStream.toString()
+                assertTrue(output.contains("Active Console Code Page")) {
+                    "Should log active console code page information"
+                }
+
+                // Check for size preservation message (may or may not appear depending on font availability)
+                // We don't assert this as it depends on system font availability
+
+            } finally {
+                System.setOut(originalOut)
+            }
+        }
+
+        @Test
+        @EnabledOnOs(OS.WINDOWS)
+        @DisplayName("should show size preservation in SETUP_OPTIMAL_CONSOLE output")
+        fun `shows size preservation in SETUP_OPTIMAL_CONSOLE output`() {
+            val outputStream = ByteArrayOutputStream()
+            val originalOut = System.out
+
+            try {
+                System.setOut(PrintStream(outputStream))
+
+                WinUtils.SETUP_OPTIMAL_CONSOLE()
+
+                val output = outputStream.toString()
+                // Should contain either success or failure message
+                assertTrue(
+                    output.contains("Console optimized") ||
+                    output.contains("No suitable Unicode fonts") ||
+                    output.contains("Windows font APIs not available")
+                ) {
+                    "Should provide feedback about console optimization attempt"
+                }
+
+            } finally {
+                System.setOut(originalOut)
+            }
+        }
+
+        @Test
+        @DisplayName("should behave consistently across platform checks")
+        fun `behaves consistently across platform checks`() {
+            val isWindows = WinUtils.IS_OS_WINDOWS()
+            val asciiSupported = WinUtils.ASCII_TABLE_SUPPORTED()
+
+            if (isWindows) {
+                // On Windows, ASCII support depends on code page
+                WinUtils.CHCP_TO_UTF8()
+                assertTrue(WinUtils.ASCII_TABLE_SUPPORTED()) {
+                    "ASCII should be supported on Windows with UTF-8"
+                }
+            } else {
+                // On non-Windows, ASCII should always be supported
+                assertTrue(asciiSupported) {
+                    "ASCII should always be supported on non-Windows platforms"
+                }
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Boundary and Contract Testing")
+    inner class BoundaryTests {
+
+        @Test
+        @DisplayName("should handle edge cases in font operations")
+        fun `handles edge cases in font operations`() {
+            // Test that font operations don't break with various inputs
+            assertDoesNotThrow {
+                WinUtils.SET_CASCADIA_CODE_FONT(Short.MIN_VALUE)
+                WinUtils.SET_CASCADIA_CODE_FONT(Short.MAX_VALUE)
+                WinUtils.SET_CASCADIA_CODE_FONT(null) // explicit null
+            }
+        }
+
+        @Test
+        @EnabledOnOs(OS.WINDOWS)
+        @DisplayName("should validate code page constants")
+        fun `validates code page constants`() {
+            assertEquals(65001, WinUtils.UTF8_CODEPAGE) {
+                "UTF-8 code page constant should be 65001"
+            }
+        }
+
+        @Test
+        @DisplayName("should maintain thread safety for static methods")
+        fun `maintains thread safety for static methods`() {
+            // Test concurrent access to static methods
+            val threads = (1..5).map { threadId ->
+                Thread {
+                    repeat(10) {
+                        assertDoesNotThrow {
+                            WinUtils.IS_OS_WINDOWS()
+                            WinUtils.ASCII_TABLE_SUPPORTED()
+                            if (WinUtils.IS_OS_WINDOWS()) {
+                                // Test both with and without size parameter
+                                WinUtils.SET_CASCADIA_CODE_FONT((12 + threadId).toShort())
+                                WinUtils.SET_CASCADIA_CODE_FONT() // size preservation
+                            }
+                        }
+                    }
+                }
+            }
+
+            threads.forEach { it.start() }
+            threads.forEach { it.join() }
+        }
+
+        @Test
+        @DisplayName("should handle API overloads correctly")
+        fun `handles API overloads correctly`() {
+            // Test that both API variations work
+            assertDoesNotThrow {
+                WinUtils.SET_CASCADIA_CODE_FONT()          // no parameter (size preservation)
+                WinUtils.SET_CASCADIA_CODE_FONT(16)        // explicit size
+                WinUtils.SET_CASCADIA_CODE_FONT(null)      // explicit null (size preservation)
+            }
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces new functionality to enhance console font management on Windows systems, along with corresponding unit tests to ensure robustness. The key changes include adding support for setting specific console fonts, optimizing the console for Unicode display, and extending the `Kernel32` interface for font operations.

### New Features for Console Font Management:
* Added `ConsoleFontInfoEx` and `Kernel32Extended` in `WinUtils.kt` to interact with Windows API for console font operations, including setting and retrieving font information.
* Introduced `SET_CASCADIA_CODE_FONT` and `SETUP_OPTIMAL_CONSOLE` methods in `WinUtils` to set the console font to Cascadia Code and optimize the console for Unicode display, respectively. These methods ensure UTF-8 support and handle edge cases gracefully.

### Unit Tests for Font Management:
* Added comprehensive tests in `WinUtilsTest.kt` to validate the new font management functionality, including tests for setting fonts, handling edge cases, and ensuring UTF-8 code page preservation. Tests are conditionally enabled based on the operating system.