### PR TITLE
Graal support

### DIFF
--- a/embabel-common-util/src/main/kotlin/com/embabel/common/util/UtilRuntimeHints.kt
+++ b/embabel-common-util/src/main/kotlin/com/embabel/common/util/UtilRuntimeHints.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.common.util
+
+import com.embabel.common.util.ConsoleFontInfoEx.Coord
+import com.sun.jna.platform.win32.Kernel32
+import org.springframework.aot.hint.MemberCategory
+import org.springframework.aot.hint.RuntimeHints
+import org.springframework.aot.hint.RuntimeHintsRegistrar
+
+class UtilRuntimeHints : RuntimeHintsRegistrar {
+    override fun registerHints(hints: RuntimeHints, classLoader: ClassLoader?) {
+        // Register dynamic proxies
+        hints.proxies().registerJdkProxy(Kernel32::class.java)
+        hints.proxies().registerJdkProxy(Kernel32Extended::class.java)
+
+        // Register types for reflection
+        hints.reflection().registerType(ConsoleFontInfoEx::class.java) {
+            it.withMembers(
+                MemberCategory.DECLARED_FIELDS,
+                MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS
+            )
+        }
+
+        hints.reflection().registerType(Coord::class.java) {
+            it.withMembers(
+                MemberCategory.DECLARED_FIELDS,
+                MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS
+            )
+        }
+
+        hints.reflection().registerType(Kernel32Extended::class.java) {
+            it.withMembers(MemberCategory.INVOKE_DECLARED_METHODS)
+        }
+    }
+}


### PR DESCRIPTION
Runtime Hints for fixing:

```
Exception in thread "main" org.graalvm.nativeimage.MissingReflectionRegistrationError: The program tried to reflectively access the proxy class inheriting

   [com.sun.jna.platform.win32.Kernel32]

without it being registered for runtime reflection. Add [com.sun.jna.platform.win32.Kernel32] to the dynamic-proxy metadata to solve this problem. Note: The order of interfaces used to create proxies matters. See https://www.graalvm.org/latest/reference-manual/native-image/metadata/#dynamic-proxy for help.
```


Used by https://github.com/embabel/embabel-agent/pull/602/files#diff-0865aca6232263b1794b704655fa2b49149335f7863d4cc0a757d4810a190309