### PR TITLE
Prepare for Maven Release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
     </parent>
     <groupId>com.embabel.common</groupId>
     <artifactId>embabel-common-parent</artifactId>
@@ -26,6 +26,13 @@
         <module>embabel-common-textio</module>
         <module>embabel-common-test</module>
     </modules>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-common</url>
+        <connection>scm:git:https://github.com/embabel/embabel-common.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-common.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
 
     <dependencyManagement>
         <dependencies>
@@ -107,8 +114,18 @@
 
     <repositories>
         <repository>
+            <id>embabel-releases</id>
+            <url>https://repo.embabel.com/artifactory/libs-release</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>embabel-snapshots</id>
             <url>https://repo.embabel.com/artifactory/libs-snapshot</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>


### PR DESCRIPTION
This pull request updates the Maven project configuration in `pom.xml` to prepare for a release version and improve project metadata. The most important changes include updating the parent version, adding SCM information, and configuring repository settings.

Versioning and metadata updates:

* Updated the parent project version from `0.1.0-SNAPSHOT` to the release version `0.1.0` to indicate a stable release.
* Added an `<scm>` section with repository URLs and connection details to improve project metadata for source control management.

Repository configuration:

* Added a new `embabel-releases` repository for release artifacts and disabled snapshots for this repository.
* Updated the `embabel-snapshots` repository configuration to explicitly disable releases and enable snapshots.