### PR TITLE
Update depdency parent version to 0.1.0

### DIFF
--- a/embabel-common-dependencies/pom.xml
+++ b/embabel-common-dependencies/pom.xml
@@ -56,9 +56,9 @@
         <repository>
             <id>embabel-snapshots</id>
             <url>https://repo.embabel.com/artifactory/libs-snapshot</url>
-            <release>
+            <releases>
                 <enabled>false</enabled>
-            </release>
+            </releases>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>


### PR DESCRIPTION
This pull request updates the parent dependency version in the `embabel-common-dependencies/pom.xml` file from a snapshot to a stable release.

- Dependency management:
  * Updated the parent artifact version from `0.1.0-SNAPSHOT` to `0.1.0` for more stable dependency resolution.