### PR TITLE
Update dependency parent to 0.1.0

### DIFF
--- a/embabel-common-test/embabel-common-test-dependencies/pom.xml
+++ b/embabel-common-test/embabel-common-test-dependencies/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath/>
     </parent>
     <groupId>com.embabel.common</groupId>
@@ -33,9 +33,19 @@
     </dependencyManagement>
 
     <repositories>
+         <repository>
+            <id>embabel-releases</id>
+            <url>https://repo.embabel.com/artifactory/libs-releases</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
         <repository>
             <id>embabel-snapshots</id>
             <url>https://repo.embabel.com/artifactory/libs-snapshot</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>


### PR DESCRIPTION
This pull request updates the Maven configuration for the `embabel-common-test-dependencies` module to improve dependency management and repository usage. The most notable changes are the update to the parent dependency version and the addition of a dedicated releases repository.

Dependency management updates:
* Updated the parent POM version from `0.1.0-SNAPSHOT` to the stable `0.1.0` release, ensuring that the module now depends on a stable version of the parent configuration.

Repository configuration improvements:
* Added a new `embabel-releases` repository for release artifacts and explicitly disabled snapshots for this repository, ensuring clear separation between release and snapshot dependencies.
* Updated the `embabel-snapshots` repository configuration to explicitly disable releases, further clarifying repository roles and reducing the risk of accidentally mixing release and snapshot dependencies.Add reference to embabel-releases repository