### PR TITLE
feat: add timeout option to LlmOptions

### DIFF
--- a/embabel-common-ai/src/main/kotlin/com/embabel/common/ai/model/LlmOptions.kt
+++ b/embabel-common-ai/src/main/kotlin/com/embabel/common/ai/model/LlmOptions.kt
@@ -22,6 +22,7 @@ import com.embabel.common.core.types.HasInfoString
 import com.embabel.common.util.indent
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Duration
 
 /**
  * Thinking config. Set on Anthropic models
@@ -86,6 +87,11 @@ interface LlmOptions : LlmHyperparameters, HasInfoString {
     val criteria: ModelSelectionCriteria?
 
     val thinking: Thinking?
+
+    /**
+     * Optional timeout for this LLM call. If provided, overrides the default client timeout.
+     */
+    val timeout: Duration?
 
     override fun infoString(
         verbose: Boolean?,
@@ -187,6 +193,7 @@ data class BuildableLlmOptions(
     override val topK: Int? = null,
     override val topP: Double? = null,
     override val thinking: Thinking? = null,
+    override val timeout: Duration? = null,
 ) : LlmOptions {
 
     fun withTemperature(temperature: Double): BuildableLlmOptions {
@@ -223,6 +230,10 @@ data class BuildableLlmOptions(
 
     fun withoutThinking(): BuildableLlmOptions {
         return copy(thinking = Thinking.NONE)
+    }
+
+    fun withTimeout(timeout: Duration): BuildableLlmOptions {
+        return copy(timeout = timeout)
     }
 
 }


### PR DESCRIPTION
### Summary
- Added a new optional `timeout` property in `LlmOptions` to allow timeout customization for LLM calls.
- Needed for https://github.com/embabel/embabel-agent/issues/664

---
### Changes
- Added `val timeout: Duration?` to LlmOptions.

---
### Why
This change enables fine-grained control per request, or by global configuration in properties files, giving developers more flexibility to handle long-running or fast-returning queries appropriately.

--- 
### Impact
- Backward-compatible: existing calls without timeout continue to work as before.
- Paves the way for more precise timeout handling in future LLM integrations.