### PR TITLE
Update build-parent to version 0.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.1.1</version>
     </parent>
     <groupId>com.embabel.common</groupId>
     <artifactId>embabel-common-parent</artifactId>


### PR DESCRIPTION
This pull request contains a minor update to the Maven project configuration. The change updates the parent project version from a snapshot to a released version, which helps ensure stability and consistency in dependency management.

* Updated the parent project version in `pom.xml` from `0.1.1-SNAPSHOT` to `0.1.1`, switching from a snapshot to a stable release.