### PR TITLE
Update build-parent to version 0.1.2-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.1</version>
+        <version>0.1.2-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.common</groupId>
     <artifactId>embabel-common-parent</artifactId>


### PR DESCRIPTION
This pull request updates the parent build version in the `pom.xml` file to use the latest snapshot version.

* Updated the parent artifact version from `0.1.1` to `0.1.2-SNAPSHOT` in `pom.xml` to track the latest build configuration.