### PR TITLE
Use spring-web compile dependency.

### DIFF
--- a/embabel-common-core/pom.xml
+++ b/embabel-common-core/pom.xml
@@ -18,8 +18,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This pull request updates a dependency in the `embabel-common-core/pom.xml` file to use a more focused library for web functionality.

* Dependency update:
  * Replaced the `spring-boot-starter-web` dependency with `spring-web` to reduce unnecessary dependencies and streamline the project.