### PR TITLE
Prepare 0.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.2</version>
+        <version>0.1.3</version>
     </parent>
     <groupId>com.embabel.common</groupId>
     <artifactId>embabel-common-parent</artifactId>


### PR DESCRIPTION
This pull request updates the parent build version in the Maven configuration to use a stable release instead of a snapshot. This change ensures that the project is built against a finalized version of its parent, improving reliability and consistency.

* Dependency management:
  * Updated the parent artifact version in `pom.xml` from `0.1.2-SNAPSHOT` to `0.1.3` to reference a stable release.