### PR TITLE
Remove dependency on OpenAi

### DIFF
--- a/embabel-common-ai/pom.xml
+++ b/embabel-common-ai/pom.xml
@@ -44,8 +44,9 @@
 
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-openai</artifactId>
+            <artifactId>spring-ai-client-chat</artifactId>
         </dependency>
+
     </dependencies>
 
 </project>


### PR DESCRIPTION
This pull request makes a small update to the `embabel-common-ai/pom.xml` file by switching the dependency from `spring-ai-openai` to `spring-ai-client-chat`. This likely reflects a move to a more general or updated Spring AI chat client library.