### PR TITLE
Feature/property configuration auto completion

### DIFF
--- a/embabel-common-ai/pom.xml
+++ b/embabel-common-ai/pom.xml
@@ -22,6 +22,23 @@
                         <arg>-Xjvm-default=all</arg>
                     </args>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>kapt</id>
+                        <goals>
+                            <goal>kapt</goal>
+                        </goals>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.springframework.boot</groupId>
+                                    <artifactId>spring-boot-configuration-processor</artifactId>
+                                    <version>${spring-boot.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -99,34 +99,6 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>kapt</id>
-                        <goals>
-                            <goal>kapt</goal>
-                        </goals>
-                        <configuration>
-                            <annotationProcessorPaths>
-                                <path>
-                                    <groupId>org.springframework.boot</groupId>
-                                    <artifactId>spring-boot-configuration-processor</artifactId>
-                                    <version>${spring-boot.version}</version>
-                                </path>
-                                <path>
-                                    <groupId>org.springframework.boot</groupId>
-                                    <artifactId>spring-boot-autoconfigure-processor</artifactId>
-                                    <version>${spring-boot.version}</version>
-                                </path>
-                            </annotationProcessorPaths>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>compile</id>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
This is slightly updated version of https://github.com/embabel/embabel-common/pull/69 contributed by
@Fj-ivy 

- Reduce scope to the common-ai module (no need to make it global for all of common modules yet)
- There is no Autoconfigurations, therefore Auto Configuration Processor is not required.

This pull request introduces improvements to the build process and the configuration properties model for the AI module. The most significant changes involve enhancing annotation processing support in the Maven build and refactoring the `ConfigurableModelProviderProperties` data class for better clarity and mutability.

**Build process improvements:**

* Added a `kapt` execution to the Maven build (`embabel-common-ai/pom.xml`) to enable annotation processing, specifically including the `spring-boot-configuration-processor` for improved Spring Boot configuration metadata generation.

**Codebase and configuration model refactoring:**

* Refactored the `ConfigurableModelProviderProperties` data class to use mutable (`var`) properties instead of immutable (`val`), and added detailed KDoc comments for each property to improve maintainability and clarity. Also reordered annotations to follow Spring conventions.