### PR TITLE
Change Maven command to include 'clean' before deploy

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -26,4 +26,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
         
-        run: mvn -DskipTests=true deploy
+        run: mvn -DskipTests=true clean deploy


### PR DESCRIPTION
This pull request makes a small update to the deployment workflow by ensuring the Maven build performs a clean before deploying. This helps prevent issues caused by leftover files from previous builds.

* In `.github/workflows/deploy-snapshots.yml`, updated the Maven deploy command to include `clean`, ensuring a clean build before deployment.