### PR TITLE
Update build parent to version 0.1.15

### DIFF
--- a/embabel-common-dependencies/pom.xml
+++ b/embabel-common-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.15-SNAPSHOT</version>
+        <version>0.1.15</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.common</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.15-SNAPSHOT</version>
+        <version>0.1.15</version>
     </parent>
     <groupId>com.embabel.common</groupId>
     <artifactId>embabel-common-parent</artifactId>


### PR DESCRIPTION
This pull request updates the parent dependency versions from a snapshot to a release version in both the main project and the common dependencies module. This change ensures that the project now relies on the stable `0.1.15` release instead of the development snapshot.

Dependency version updates:

* Updated the parent version in `pom.xml` from `0.1.15-SNAPSHOT` to the stable release `0.1.15`.
* Updated the parent version in `embabel-common-dependencies/pom.xml` from `0.1.15-SNAPSHOT` to `0.1.15`.