### PR TITLE
Prepare for 1.0.0 GA Release

### DIFF
--- a/embabel-common-dependencies/pom.xml
+++ b/embabel-common-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.15</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.common</groupId>

--- a/embabel-common-test/embabel-common-test-dependencies/pom.xml
+++ b/embabel-common-test/embabel-common-test-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.15</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.common</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.15</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.common</groupId>
     <artifactId>embabel-common-parent</artifactId>


### PR DESCRIPTION
This pull request updates the parent dependency versions in several Maven `pom.xml` files to use the new `1.0.0-SNAPSHOT` version instead of `0.1.15`. This ensures all modules are aligned with the latest snapshot version during development.

Dependency version updates:

* Updated the parent version to `1.0.0-SNAPSHOT` in `embabel-common-dependencies/pom.xml`
* Updated the parent version to `1.0.0-SNAPSHOT` in `embabel-common-test/embabel-common-test-dependencies/pom.xml`
* Updated the parent version to `1.0.0-SNAPSHOT` in the root `pom.xml`