### PR TITLE
Prepare for 1.0.0 Release

### DIFF
--- a/embabel-common-dependencies/pom.xml
+++ b/embabel-common-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.common</groupId>

--- a/embabel-common-test/embabel-common-test-dependencies/pom.xml
+++ b/embabel-common-test/embabel-common-test-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.common</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <groupId>com.embabel.common</groupId>
     <artifactId>embabel-common-parent</artifactId>


### PR DESCRIPTION
This pull request updates the parent POM versions from the snapshot version `1.0.0-SNAPSHOT` to the stable release `1.0.0` across several Maven project files. This change ensures that all modules now depend on the released version of the parent POMs, improving build stability and consistency.

Dependency version updates:

* Updated the parent POM version to `1.0.0` in `pom.xml`, switching from the snapshot version for the main project parent.
* Updated the parent POM version to `1.0.0` in `embabel-common-dependencies/pom.xml`.
* Updated the parent POM version to `1.0.0` in `embabel-common-test/embabel-common-test-dependencies/pom.xml`.