### PR TITLE
2.0.0 synchup 1.0.0

### DIFF
--- a/embabel-common-core/pom.xml
+++ b/embabel-common-core/pom.xml
@@ -31,7 +31,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
+            <groupId>tools.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
 

--- a/embabel-common-core/pom.xml
+++ b/embabel-common-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.common</groupId>
         <artifactId>embabel-common-parent</artifactId>
-        <version>0.1.13-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>embabel-common-core</artifactId>
     <packaging>jar</packaging>

--- a/embabel-common-core/src/main/kotlin/com/embabel/common/core/Versioned.kt
+++ b/embabel-common-core/src/main/kotlin/com/embabel/common/core/Versioned.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.common.core
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import tools.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ResponseStatus

--- a/embabel-common-dependencies/pom.xml
+++ b/embabel-common-dependencies/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>com.embabel.common</groupId>
     <artifactId>embabel-common-dependencies</artifactId>
-    <version>0.1.13-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Embabel Common Dependencies</name>
     <description>Embabel Common Dependencies for internal or external modules</description>

--- a/embabel-common-test/embabel-common-test-dependencies/pom.xml
+++ b/embabel-common-test/embabel-common-test-dependencies/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>com.embabel.common</groupId>
     <artifactId>embabel-common-test-dependencies</artifactId>
-    <version>0.1.13-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Embabel Common Test Dependencies</name>
     <description>Embabel Common Test Framework Dependencies</description>

--- a/embabel-common-test/embabel-common-test-neo/pom.xml
+++ b/embabel-common-test/embabel-common-test-neo/pom.xml
@@ -34,6 +34,12 @@
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-neo4j</artifactId>
         </dependency>
+
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-data-neo4j-test</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/embabel-common-test/embabel-common-test-neo/pom.xml
+++ b/embabel-common-test/embabel-common-test-neo/pom.xml
@@ -26,7 +26,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
+            <groupId>tools.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
 

--- a/embabel-common-test/embabel-common-test-neo/pom.xml
+++ b/embabel-common-test/embabel-common-test-neo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.common</groupId>
         <artifactId>embabel-common-test</artifactId>
-        <version>0.1.13-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>embabel-common-test-neo</artifactId>
     <packaging>jar</packaging>

--- a/embabel-common-test/embabel-common-test-neo/src/main/kotlin/com/embabel/common/test/neo/NeoIntegrationTest.kt
+++ b/embabel-common-test/embabel-common-test-neo/src/main/kotlin/com/embabel/common/test/neo/NeoIntegrationTest.kt
@@ -16,19 +16,15 @@
 package com.embabel.test.neo
 
 
+import org.springframework.boot.data.neo4j.test.autoconfigure.AutoConfigureDataNeo4j
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.test.autoconfigure.data.neo4j.AutoConfigureDataNeo4j
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
-//import org.testcontainers.junit.jupiter.Testcontainers
 
 /**
  * Stereotype annotation for Spring integration test using Neo
  */
 @AutoConfigureDataNeo4j
 @EnableAutoConfiguration
-//@Testcontainers
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 @Transactional

--- a/embabel-common-test/embabel-common-test-neo/src/main/kotlin/com/embabel/common/test/neo/NeoIntegrationTestSupport.kt
+++ b/embabel-common-test/embabel-common-test-neo/src/main/kotlin/com/embabel/common/test/neo/NeoIntegrationTestSupport.kt
@@ -16,7 +16,7 @@
 package com.embabel.common.test.neo
 
 import com.embabel.test.neo.NeoIntegrationTest
-import com.fasterxml.jackson.databind.ObjectMapper
+import tools.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Profile

--- a/embabel-common-test/pom.xml
+++ b/embabel-common-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.common</groupId>
         <artifactId>embabel-common-parent</artifactId>
-        <version>0.1.13-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>embabel-common-test</artifactId>
     <packaging>pom</packaging>

--- a/embabel-common-textio/pom.xml
+++ b/embabel-common-textio/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.common</groupId>
         <artifactId>embabel-common-parent</artifactId>
-        <version>0.1.13-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>embabel-common-textio</artifactId>
     <packaging>jar</packaging>

--- a/embabel-common-util/pom.xml
+++ b/embabel-common-util/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
+            <groupId>tools.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
 

--- a/embabel-common-util/pom.xml
+++ b/embabel-common-util/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.common</groupId>
         <artifactId>embabel-common-parent</artifactId>
-        <version>0.1.13-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>embabel-common-util</artifactId>
     <packaging>jar</packaging>

--- a/embabel-common-util/src/main/kotlin/com/embabel/common/util/ComputerSaysNoSerializer.kt
+++ b/embabel-common-util/src/main/kotlin/com/embabel/common/util/ComputerSaysNoSerializer.kt
@@ -15,9 +15,9 @@
  */
 package com.embabel.common.util
 
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.JsonSerializer
-import com.fasterxml.jackson.databind.SerializerProvider
+import tools.jackson.core.JsonGenerator
+import tools.jackson.databind.SerializationContext
+import tools.jackson.databind.ValueSerializer
 
 /**
  * Use @JsonSerialize(using = ComputerSaysNoSerializer.class) to prevent serialization of
@@ -28,9 +28,9 @@ import com.fasterxml.jackson.databind.SerializerProvider
  *
  * @param <T>
 </T> */
-class ComputerSaysNoSerializer<T> : JsonSerializer<T>() {
+class ComputerSaysNoSerializer<T> : ValueSerializer<T>() {
 
-    override fun serialize(value: T, gen: JsonGenerator, serializers: SerializerProvider) {
+    override fun serialize(value: T, gen: JsonGenerator, serializers: SerializationContext) {
         throw IllegalArgumentException(
             "Computer says no to serializing objects of type ${value!!::class.java.name} as it is internal"
         )

--- a/embabel-common-util/src/test/kotlin/com/embabel/common/util/StringTrimmingUtilsKtTest.kt
+++ b/embabel-common-util/src/test/kotlin/com/embabel/common/util/StringTrimmingUtilsKtTest.kt
@@ -18,7 +18,6 @@ package com.embabel.common.util
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.function.Executable
 
 internal class StringTrimmingUtilsTest {
 
@@ -28,16 +27,16 @@ internal class StringTrimmingUtilsTest {
         internal inner class TestInvalidArgs {
             @Test
             fun testMaxLessThanKeepRight() {
-                Assertions.assertThrows<java.lang.IllegalArgumentException?>(
-                    java.lang.IllegalArgumentException::class.java,
-                    Executable { trim("foo", 10, 11) })
+                Assertions.assertThrows(IllegalArgumentException::class.java) {
+                    trim("foo", 10, 11)
+                }
             }
 
             @Test
             fun testMaxLessThanEllipsis() {
-                Assertions.assertThrows<java.lang.IllegalArgumentException?>(
-                    IllegalArgumentException::class.java,
-                    Executable { trim("foo", 2, 1, "weroiwueoiruwoeiruowieurowieuruwieur") })
+                Assertions.assertThrows(IllegalArgumentException::class.java) {
+                    trim("foo", 2, 1, "weroiwueoiruwoeiruowieurowieuruwieur")
+                }
             }
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.14-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.common</groupId>
     <artifactId>embabel-common-parent</artifactId>
-    <version>0.1.13-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Embabel Common Parent</name>
     <description>Common dependencies shared by child modules.</description>


### PR DESCRIPTION
This pull request upgrades the project to version `2.0.0-SNAPSHOT` and migrates from the `com.fasterxml.jackson` library to the `tools.jackson` namespace throughout the codebase. Additionally, it updates dependencies, refactors code to use the new Jackson APIs, and improves test code readability. A new test dependency for Spring Boot Neo4j integration is also added.

**Version Upgrades and Dependency Management:**

* Bump all module and parent versions from `1.0.1-SNAPSHOT` (or `1.0.0`) to `2.0.0-SNAPSHOT` in all `pom.xml` files, including the root and submodules. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L7-R11) [[2]](diffhunk://#diff-7be380f5e0c9f11ad3c61d6643129230d8736a6c83388e0bd3903ab38c424dcdL7-R7) [[3]](diffhunk://#diff-0e3fdedb8455c8328f840d80ffe03435e184e37f2f5ed4d12c34e66efba89b7eL12-R12) [[4]](diffhunk://#diff-6933ead185e02aa51e35f863660aa72fba9b2cbd3dec13ce43d82c156ebd5f9cL12-R12) [[5]](diffhunk://#diff-545332445dcfac6487586584baef69322545eba3c3fec066b7fb7d3f2150880dL7-R7) [[6]](diffhunk://#diff-44ff3f5f25373a258c54f648f8ff4def6d7c53a911480f387851b4aea5d191a0L7-R7) [[7]](diffhunk://#diff-393901ff195cd163c3fd0c62fa618ebc597759170c3fd02c1c49271ac0797f0fL7-R7) [[8]](diffhunk://#diff-a5e090c117815709b5c209a12ea357715490461221e75b85a3e72768a692b1bbL7-R7)
* Update the group ID for the `jackson-module-kotlin` dependency from `com.fasterxml.jackson.module` to `tools.jackson.module` in all relevant `pom.xml` files. [[1]](diffhunk://#diff-7be380f5e0c9f11ad3c61d6643129230d8736a6c83388e0bd3903ab38c424dcdL34-R34) [[2]](diffhunk://#diff-545332445dcfac6487586584baef69322545eba3c3fec066b7fb7d3f2150880dL29-R42) [[3]](diffhunk://#diff-a5e090c117815709b5c209a12ea357715490461221e75b85a3e72768a692b1bbL39-R39)

**Jackson Migration:**

* Refactor all Jackson imports in Kotlin code from `com.fasterxml.jackson` to `tools.jackson`, including serializers and annotations. [[1]](diffhunk://#diff-dbecfdd53a7db257ee61bcffd120e12ae54ce5d7b740e94042adc4a70dfdeb60L18-R18) [[2]](diffhunk://#diff-fe788acbb74182716c9856ee8843382177a32352fa5cf09d0b4f944ba77a6a14L19-R19) [[3]](diffhunk://#diff-591b4072b27f93446792e8f23df41b5fd238c6adb8a311ea3546a7557cd9c205L18-R20)
* Update the custom serializer `ComputerSaysNoSerializer` to extend `ValueSerializer` and use `SerializationContext` instead of the deprecated `JsonSerializer` and `SerializerProvider`.

**Testing Improvements:**

* Add the `spring-boot-data-neo4j-test` dependency for improved Neo4j integration testing in `embabel-common-test-neo`.
* Refactor test assertions in `StringTrimmingUtilsKtTest.kt` to use lambda-based `assertThrows` for better readability and idiomatic Kotlin. [[1]](diffhunk://#diff-2a8a5113e9d063e43464c46b4cafc867aab0e9766e39ef78b916df45da1b78cbL21) [[2]](diffhunk://#diff-2a8a5113e9d063e43464c46b4cafc867aab0e9766e39ef78b916df45da1b78cbL31-R39)

**Spring Boot Annotation Update:**

* Update the import for `AutoConfigureDataNeo4j` to use the new package path in `NeoIntegrationTest.kt`.

These changes collectively modernize the codebase, ensure compatibility with the latest Jackson library, and streamline testing and dependency management.