### PR TITLE
Prepare for Release

### DIFF
--- a/embabel-common-dependencies/pom.xml
+++ b/embabel-common-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>1.0.0</version>
+        <version>2.0.0</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.common</groupId>

--- a/embabel-common-test/embabel-common-test-dependencies/pom.xml
+++ b/embabel-common-test/embabel-common-test-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>1.0.0</version>
+        <version>2.0.0</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.common</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
     </parent>
     <groupId>com.embabel.common</groupId>
     <artifactId>embabel-common-parent</artifactId>


### PR DESCRIPTION
This pull request updates the parent dependency versions across multiple Maven POM files to use the latest stable release. This ensures that all modules are aligned with the new `2.0.0` version, rather than older or snapshot versions.

Dependency version updates:

* Updated the parent version in `pom.xml` from `2.0.0-SNAPSHOT` to `2.0.0` to use the stable build parent.
* Updated the parent version in `embabel-common-dependencies/pom.xml` from `1.0.0` to `2.0.0` for consistency with the latest dependencies parent.
* Updated the parent version in `embabel-common-test/embabel-common-test-dependencies/pom.xml` from `1.0.0` to `2.0.0` for consistency with the latest dependencies parent.