### PR TITLE
Feature: add includedTags/excludedTags filtering to ThinkingBlocks

### DIFF
--- a/embabel-common-core/src/main/kotlin/com/embabel/common/core/thinking/spi/thinkingBlocksExtraction.kt
+++ b/embabel-common-core/src/main/kotlin/com/embabel/common/core/thinking/spi/thinkingBlocksExtraction.kt
@@ -20,14 +20,21 @@ import com.embabel.common.core.thinking.ThinkingTagType
 import com.embabel.common.core.thinking.ThinkingTags
 
 /**
- * Extract all thinking blocks from input text.
+ * Extract all thinking blocks from input text, with optional tag-name filtering.
  *
  * Processes the input text to find and extract all thinking content
  * in various formats (tagged, prefix, or untagged), returning detailed
  * metadata about each block found.
+ *
+ * [includedTags] and [excludedTags] apply only to [ThinkingTagType.TAG] blocks.
+ * [ThinkingTagType.PREFIX] and [ThinkingTagType.NO_PREFIX] blocks always pass through.
  */
 @InternalThinkingApi
-fun extractAllThinkingBlocks(input: String): List<ThinkingBlock> {
+fun extractAllThinkingBlocks(
+    input: String,
+    includedTags: Set<String>? = null,
+    excludedTags: Set<String>? = null,
+): List<ThinkingBlock> {
     val blocks = mutableListOf<ThinkingBlock>()
 
     // Extract thinking blocks in priority order: Tags (most common) → Prefix → No Prefix (least common)
@@ -120,7 +127,25 @@ fun extractAllThinkingBlocks(input: String): List<ThinkingBlock> {
         }
     }
 
-    return blocks.sortedBy { input.indexOf(it.content) }
+    return filterBlocks(blocks, includedTags, excludedTags).sortedBy { input.indexOf(it.content) }
+}
+
+private fun filterBlocks(
+    blocks: List<ThinkingBlock>,
+    includedTags: Set<String>?,
+    excludedTags: Set<String>?,
+): List<ThinkingBlock> {
+    if (includedTags == null && excludedTags == null) return blocks
+    return blocks.filter { block ->
+        when (block.tagType) {
+            ThinkingTagType.TAG -> {
+                val isIncluded = includedTags == null || block.tagValue in includedTags
+                val isNotExcluded = excludedTags == null || block.tagValue !in excludedTags
+                isIncluded && isNotExcluded
+            }
+            else -> true
+        }
+    }
 }
 
 /**

--- a/embabel-common-core/src/test/kotlin/com/embabel/common/core/thinking/spi/ThinkingBlocksExtractionTest.kt
+++ b/embabel-common-core/src/test/kotlin/com/embabel/common/core/thinking/spi/ThinkingBlocksExtractionTest.kt
@@ -453,7 +453,7 @@ class ThinkingBlocksExtractionTest {
     // ====================
 
     @Test
-    fun `includedTags keeps only matching TAG blocks; PREFIX and NO_PREFIX pass through`() {
+    fun `includedTags keeps only matching TAG blocks and PREFIX and NO_PREFIX pass through`() {
         val input = """
             <think>think content</think>
             <analysis>analysis content</analysis>

--- a/embabel-common-core/src/test/kotlin/com/embabel/common/core/thinking/spi/ThinkingBlocksExtractionTest.kt
+++ b/embabel-common-core/src/test/kotlin/com/embabel/common/core/thinking/spi/ThinkingBlocksExtractionTest.kt
@@ -449,7 +449,78 @@ class ThinkingBlocksExtractionTest {
     }
 
     // ====================
-    // 4. Order & Priority
+    // 4. Tag Filtering
+    // ====================
+
+    @Test
+    fun `includedTags keeps only matching TAG blocks; PREFIX and NO_PREFIX pass through`() {
+        val input = """
+            <think>think content</think>
+            <analysis>analysis content</analysis>
+            //THINKING: prefix content
+            No-prefix content here.
+            {"result": "x"}
+        """.trimIndent()
+
+        val blocks = extractAllThinkingBlocks(input, includedTags = setOf("think"))
+
+        // TAG: only "think" kept, "analysis" dropped
+        val tagBlocks = blocks.filter { it.tagType == ThinkingTagType.TAG }
+        assertEquals(1, tagBlocks.size)
+        assertEquals("think", tagBlocks.first().tagValue)
+        // PREFIX and NO_PREFIX always pass through
+        assertTrue(blocks.any { it.tagType == ThinkingTagType.PREFIX })
+        assertTrue(blocks.any { it.tagType == ThinkingTagType.NO_PREFIX })
+    }
+
+    @Test
+    fun `includedTags with multiple tags keeps all matching TAG blocks`() {
+        val input = """
+            <think>think content</think>
+            <analysis>analysis content</analysis>
+            <plan>plan content</plan>
+            {"result": "x"}
+        """.trimIndent()
+
+        val blocks = extractAllThinkingBlocks(input, includedTags = setOf("think", "plan"))
+
+        assertEquals(2, blocks.size)
+        assertEquals(setOf("think", "plan"), blocks.map { it.tagValue }.toSet())
+    }
+
+    @Test
+    fun `excludedTags removes matching TAG blocks and passes through PREFIX and NO_PREFIX`() {
+        val input = """
+            <think>think content</think>
+            <analysis>analysis content</analysis>
+            //THINKING: prefix content
+            {"result": "x"}
+        """.trimIndent()
+
+        val blocks = extractAllThinkingBlocks(input, excludedTags = setOf("think"))
+
+        assertEquals(2, blocks.size)
+        assertTrue(blocks.none { it.tagValue == "think" })
+        assertTrue(blocks.any { it.tagType == ThinkingTagType.TAG && it.tagValue == "analysis" })
+        assertTrue(blocks.any { it.tagType == ThinkingTagType.PREFIX })
+    }
+
+    @Test
+    fun `null includedTags and excludedTags returns all blocks unchanged`() {
+        val input = """
+            <think>think content</think>
+            //THINKING: prefix content
+            {"result": "x"}
+        """.trimIndent()
+
+        val unfiltered = extractAllThinkingBlocks(input)
+        val filtered = extractAllThinkingBlocks(input, includedTags = null, excludedTags = null)
+
+        assertEquals(unfiltered.size, filtered.size)
+    }
+
+    // ====================
+    // 5. Order & Priority
     // ====================
 
     @Test


### PR DESCRIPTION
# Summary

  - Adds optional `includedTags` and `excludedTags` parameters to `extractAllThinkingBlocks`
  - Filtering is applied via a private `filterBlocks` function after extraction — the algorithm body is untouched
  - Both filters apply only to named `TAG` blocks; `PREFIX` and `NO_PREFIX` blocks always pass through
  - Covered by new "Tag Filtering" section in `ThinkingBlocksExtractionTest`

  ## Notes

  Required by `embabel-agent` PR (tag selection feature on `Thinking` class).

See Issue 1790 on embabel-agent
