### PR TITLE
Prepare for 1.5.1 Release

### DIFF
--- a/embabel-common-dependencies/pom.xml
+++ b/embabel-common-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.1</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.common</groupId>

--- a/embabel-common-test/embabel-common-test-dependencies/pom.xml
+++ b/embabel-common-test/embabel-common-test-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.1</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.common</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
     <groupId>com.embabel.common</groupId>
     <artifactId>embabel-common-parent</artifactId>


### PR DESCRIPTION
This pull request updates the parent dependency versions from the snapshot (`2.0.1-SNAPSHOT`) to the stable release (`2.0.1`) across several Maven `pom.xml` files. This change ensures all modules now depend on the released version of the parent dependencies, which improves build stability and consistency.

Dependency version updates:

* Updated the parent version in `pom.xml` from `2.0.1-SNAPSHOT` to `2.0.1`.
* Updated the parent version in `embabel-common-dependencies/pom.xml` from `2.0.1-SNAPSHOT` to `2.0.1`.
* Updated the parent version in `embabel-common-test/embabel-common-test-dependencies/pom.xml` from `2.0.1-SNAPSHOT` to `2.0.1`.