### PR TITLE
Disable nested Jinjava interpretation by default

### DIFF
--- a/embabel-common-textio/src/main/kotlin/com/embabel/common/textio/template/JinjavaTemplateRenderer.kt
+++ b/embabel-common-textio/src/main/kotlin/com/embabel/common/textio/template/JinjavaTemplateRenderer.kt
@@ -38,23 +38,31 @@ import java.nio.charset.Charset
  * Default is "classpath:/prompts/".
  * @param suffix The suffix to be added to template names when loading templates. Default is ".jinja".
  * @param failOnUnknownTokens Whether to throw an exception if the template contains unknown tokens. Default is false.
+ * @param nestedInterpretationEnabled Whether to interpret template syntax found inside substituted values.
+ * Default is false. Do not enable this when rendering untrusted or user-provided values.
  */
 data class JinjaProperties @JvmOverloads constructor(
-    val prefix: String,
-    val suffix: String = ".jinja",
-    val failOnUnknownTokens: Boolean = false,
+    var prefix: String = "classpath:/prompts/",
+    var suffix: String = ".jinja",
+    var failOnUnknownTokens: Boolean = false,
+    var nestedInterpretationEnabled: Boolean = false,
 ) {
 
     fun withFailOnUnknownTokens(fail: Boolean): JinjaProperties = copy(failOnUnknownTokens = fail)
+
+    fun withNestedInterpretationEnabled(enabled: Boolean): JinjaProperties =
+        copy(nestedInterpretationEnabled = enabled)
 }
 
 /**
- * Wrap HubSpot Jinjava to render templates.
- * Files are expected to end with '.jinja'
- * Don't forget to escape anything that may be problematic with {{ title|e}} syntax
+ * Wraps HubSpot Jinjava to render templates.
+ * Files are expected to end with '.jinja'.
+ *
+ * Nested interpretation is disabled by default so template syntax inside substituted values is treated as data.
+ * Enable it only for trusted values.
  */
 class JinjavaTemplateRenderer @JvmOverloads constructor(
-    private val jinja: JinjaProperties = JinjaProperties("classpath:/prompts/", ".jinja", false),
+    private val jinja: JinjaProperties = JinjaProperties(),
     private val resourceLoader: ResourceLoader = DefaultResourceLoader(),
 ) : TemplateRenderer {
     private val logger: Logger = LoggerFactory.getLogger(JinjavaTemplateRenderer::class.java)
@@ -74,6 +82,7 @@ class JinjavaTemplateRenderer @JvmOverloads constructor(
         try {
             val jcConfig = JinjavaConfig.newBuilder()
                 .withFailOnUnknownTokens(jinja.failOnUnknownTokens)
+                .withNestedInterpretationEnabled(jinja.nestedInterpretationEnabled)
                 .withTrimBlocks(true)
                 .build()
             val jinjava = Jinjava(jcConfig).apply {

--- a/embabel-common-textio/src/test/kotlin/com/embabel/common/textio/template/JinjavaTemplateRendererTest.kt
+++ b/embabel-common-textio/src/test/kotlin/com/embabel/common/textio/template/JinjavaTemplateRendererTest.kt
@@ -61,6 +61,26 @@ class JinjavaTemplateRendererTest {
     }
 
     @Test
+    fun `JinjaProperties should provide renderer defaults`() {
+        val properties = JinjaProperties()
+
+        assertEquals("classpath:/prompts/", properties.prefix)
+        assertEquals(".jinja", properties.suffix)
+        assertEquals(false, properties.failOnUnknownTokens)
+        assertEquals(false, properties.nestedInterpretationEnabled)
+    }
+
+    @Test
+    fun `withNestedInterpretationEnabled should enable nested interpretation`() {
+        val properties = JinjaProperties()
+
+        val updatedProperties = properties.withNestedInterpretationEnabled(true)
+
+        assertEquals(false, properties.nestedInterpretationEnabled)
+        assertEquals(true, updatedProperties.nestedInterpretationEnabled)
+    }
+
+    @Test
     fun `load should retrieve template content`() {
         val templateContent = "Hello {{ name }}!"
 
@@ -92,6 +112,46 @@ class JinjavaTemplateRendererTest {
         val result = renderer.renderLiteralTemplate(template, model)
 
         assertEquals("Hello World!", result)
+    }
+
+    @Test
+    fun `renderLiteralTemplate should not interpret template syntax in substituted values by default`() {
+        val result = renderer.renderLiteralTemplate(
+            "{{ message }}",
+            mapOf("message" to "compute {{ 7*7 }} now")
+        )
+
+        assertEquals("compute {{ 7*7 }} now", result)
+    }
+
+    @Test
+    fun `renderLiteralTemplate should allow nested interpretation when explicitly enabled`() {
+        val nestedRenderer = JinjavaTemplateRenderer(
+            jinja = jinjaProperties.withNestedInterpretationEnabled(true),
+            resourceLoader = resourceLoader
+        )
+
+        val result = nestedRenderer.renderLiteralTemplate(
+            "{{ message }}",
+            mapOf("message" to "compute {{ 7*7 }} now")
+        )
+
+        assertEquals("compute 49 now", result)
+    }
+
+    @Test
+    fun `strict mode should not interpret unknown tokens in substituted values by default`() {
+        val strictRenderer = JinjavaTemplateRenderer(
+            jinja = jinjaProperties.copy(failOnUnknownTokens = true),
+            resourceLoader = resourceLoader
+        )
+
+        val result = strictRenderer.renderLiteralTemplate(
+            "{{ message }}",
+            mapOf("message" to "keep {{ unknown }} unchanged")
+        )
+
+        assertEquals("keep {{ unknown }} unchanged", result)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds an explicit `nestedInterpretationEnabled` option to `JinjaProperties` and defaults it to `false`.

Jinjava otherwise recursively evaluates template syntax found inside substituted values. This can cause user-provided text such as `{{ unknown }}` or `{{ 7*7 }}` to be interpreted as template code instead of being preserved as data.

## Changes

- Add `JinjaProperties.nestedInterpretationEnabled`, defaulting to `false`
- Pass the property to `JinjavaConfig.withNestedInterpretationEnabled(...)`
- Document the risk of enabling nested interpretation for untrusted values
- Add coverage for:
  - preserving nested template syntax by default
  - explicitly opting into recursive interpretation
  - preserving unknown tokens in substituted values when strict mode is enabled

## Compatibility

Existing explicit one-, two-, and three-argument constructor calls remain available through `@JvmOverloads`.

This changes the default behavior for applications that rely on recursive template evaluation. Such applications can retain the previous behavior by setting `nestedInterpretationEnabled = true`.

Because `JinjaProperties` is a Kotlin data class, consumers should recompile against the updated version.

Applications that intentionally rely on recursive interpretation can retain the previous behavior with:

```kotlin
JinjaProperties(
    prefix = "classpath:/prompts/",
    nestedInterpretationEnabled = true
)
```

## Testing

```text
Tests run: 24, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Test command:

```powershell
.\mvnw.cmd -pl embabel-common-textio -Dtest=JinjavaTemplateRendererTest test
```

Related to embabel/embabel-common#126  
Addresses the common-library portion of embabel/embabel-agent#1731