### PR TITLE
Upgrad to Boot 4.1.1 and Spring AI 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.common</groupId>
     <artifactId>embabel-common-parent</artifactId>


### PR DESCRIPTION
This pull request updates the Maven parent version in the `pom.xml` file to use the latest snapshot version.

- Dependency management:
  * Updated the parent POM version from `2.0.1` to `2.0.2-SNAPSHOT` in `pom.xml` to reference the latest snapshot for build configuration.