### PR TITLE
chore: upgrade GitHub Actions runtimes

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: maven
       - name: Configure Maven Settings
-        uses: s4u/maven-settings-action@v2.8.0
+        uses: s4u/maven-settings-action@v4.0.0
         with:
           servers: ${{secrets.EMBABEL_ARTIFACTORY}}
       - name: Build and analyze
@@ -35,7 +35,7 @@ jobs:
         run: mvn -P flatten-pom -DskipTests=true clean deploy
 
       - name: Trigger downstream module builds
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.PAT_TOKEN }}
           repository: embabel/embabel-agent

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,9 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           java-version: '21'
           distribution: 'temurin'


### PR DESCRIPTION
## Summary

Upgrade deprecated GitHub Actions to releases using the Node.js 24 runtime.

## Changes

- Upgrade `actions/checkout` from v4 to v7.
- Upgrade `actions/setup-java` from v4 to v6.
- Upgrade `s4u/maven-settings-action` from v2.8.0 to v4.0.0.
- Upgrade `peter-evans/repository-dispatch` from v3 to v4.

Existing workflow conditions, inputs, secrets, and behavior remain unchanged.

## Validation

- `actionlint` passed.
- YAML lint passed.
- `git diff --check` passed.
- Verified that all upgraded tags exist and use Node.js 24.
- Confirmed no affected deprecated action references remain under `.github`.
- No Maven build or other heavy test suite was run.

## Related issue

- embabel/embabel-agent#1999